### PR TITLE
Add dbus-python to requirements_linux.txt for notifications

### DIFF
--- a/ClipCascade_Desktop/src/requirements_linux.txt
+++ b/ClipCascade_Desktop/src/requirements_linux.txt
@@ -8,3 +8,4 @@ xxhash==3.5.0
 pyfiglet==1.0.2
 beautifulsoup4==4.12.3
 aiortc==1.10.0
+dbus-python==1.4.0


### PR DESCRIPTION
I'm not sure what the role of CLI vs. GUI is; maybe it should be added to all 3 requirement files?