### PR TITLE
Add `pyproject.toml` for the Linux desktop python package

### DIFF
--- a/ClipCascade_Desktop/src/main.py
+++ b/ClipCascade_Desktop/src/main.py
@@ -16,6 +16,8 @@ class Main:
     def __init__(self):
         Application().run()
 
+def main():
+    Main()
 
 if __name__ == "__main__":
-    Main()
+    main()

--- a/ClipCascade_Desktop/src/pyproject.toml
+++ b/ClipCascade_Desktop/src/pyproject.toml
@@ -32,7 +32,7 @@ packages = ["cli", "clipboard", "core", "gui", "interfaces", "p2p", "stomp_ws", 
 py-modules = ["main"]
 
 [tool.setuptools.dynamic]
-dependencies = {file = ["requirements-linux.txt"]}
+dependencies = {file = ["requirements_linux.txt"]}
 
 [project.urls]
 Homepage = "https://clipcascade.sathvik.dev/"

--- a/ClipCascade_Desktop/src/pyproject.toml
+++ b/ClipCascade_Desktop/src/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "clipcascade"
+version = "3.1.0"
+description = "ClipCascade is a lightweight utility that automatically syncs the clipboard across devices, no key press required."
+authors = [{name = "Sathvik Rao", email = "your.email@example.com"}]
+license = {file = "LICENSE"}
+requires-python = ">=3.8"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: End Users/Desktop",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+
+dynamic = ["dependencies"]
+
+[project.scripts]
+clipcascade = "main:main"
+
+[tool.setuptools]
+packages = ["cli", "clipboard", "core", "gui", "interfaces", "p2p", "stomp_ws", "utils"]
+py-modules = ["main"]
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements-linux.txt"]}
+
+[project.urls]
+Homepage = "https://clipcascade.sathvik.dev/"
+Repository = "https://github.com/Sathvik-Rao/ClipCascade"
+Issues = "https://github.com/Sathvik-Rao/ClipCascade/issues"


### PR DESCRIPTION
## Description

I added the `pyproject.toml` file so that the package + dependencies can be install as a tool using `uv tool install ClipCascade_Desktop/src` after cloning the repo.

You might need to run `uv tool update-shell` to make sure the installed tools are added to your `PATH`.

Once installed as a tool, you can just run `clipcascade` to start the application.

Currently, the `pyproject.toml` uses the `requirements_linux.txt` hardcoded. Ideally, it should select the proper requirements file depending on the platform. I'll update this part once I test it on other platforms. 