### PR TITLE
feat(macos): hide dock icon and add startup error dialog

### DIFF
--- a/ClipCascade_Desktop/src/.gitignore
+++ b/ClipCascade_Desktop/src/.gitignore
@@ -1,3 +1,7 @@
 **/__pycache__/
 *.log
 DATA
+build/
+dist/
+*.spec.bak
+.venv/

--- a/ClipCascade_Desktop/src/ClipCascade_macos.spec
+++ b/ClipCascade_Desktop/src/ClipCascade_macos.spec
@@ -1,0 +1,49 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+import certifi
+
+a = Analysis(
+    ['main.py'],
+    pathex=[],
+    binaries=[],
+    datas=[(certifi.where(), 'certifi')],
+    hiddenimports=['tkinter'],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='ClipCascade',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=['../../logo/logo.icns'],
+)
+app = BUNDLE(
+    exe,
+    name='ClipCascade.app',
+    icon='../../logo/logo.icns',
+    bundle_identifier=None,
+    info_plist={
+        'LSUIElement': True,
+    },
+)

--- a/ClipCascade_Desktop/src/gui/tray.py
+++ b/ClipCascade_Desktop/src/gui/tray.py
@@ -47,6 +47,14 @@ class TaskbarPanel:
         self.root = tk.Tk()
         self.root.withdraw()  # Hide the root window
 
+        # Hide dock icon on macOS after creating tkinter window
+        if PLATFORM == MACOS:
+            try:
+                from AppKit import NSApplication, NSApplicationActivationPolicyAccessory
+                NSApplication.sharedApplication().setActivationPolicy_(NSApplicationActivationPolicyAccessory)
+            except ImportError:
+                pass
+
         # Initial state: Connected
         self.is_connected = True
 

--- a/ClipCascade_Desktop/src/main.py
+++ b/ClipCascade_Desktop/src/main.py
@@ -9,13 +9,42 @@
 # This script serves as the entry point for the ClipCascade application,
 # initializing and running the core application logic.
 
-from core.application import Application
+import sys
+import platform
 
 
-class Main:
-    def __init__(self):
-        Application().run()
+def show_error_dialog(title, message):
+    """Show native error dialog using osascript (macOS) or fallback to console."""
+    if platform.system() == "Darwin":
+        import subprocess
+
+        def sanitize(text):
+            return (text
+                .replace("\\", "")
+                .replace('"', "'")
+                .replace("\n", " ")
+                .replace("\r", " ")
+                .replace("\t", " "))
+
+        safe_msg = sanitize(message)
+        safe_title = sanitize(title)
+        script = f'display dialog "{safe_msg}" with title "{safe_title}" buttons {{"OK"}} default button 1 with icon stop'
+        try:
+            subprocess.run(["osascript", "-e", script], check=False)
+        except Exception:
+            pass
+    print(f"{title}: {message}", file=sys.stderr)
 
 
 if __name__ == "__main__":
-    Main()
+    try:
+        from core.application import Application
+
+        Application().run()
+    except Exception as e:
+        import traceback
+
+        error_msg = f"{type(e).__name__}: {e}"
+        show_error_dialog("ClipCascade Error", error_msg)
+        traceback.print_exc()
+        sys.exit(1)

--- a/ClipCascade_Desktop/src/requirements_mac.txt
+++ b/ClipCascade_Desktop/src/requirements_mac.txt
@@ -10,3 +10,4 @@ websocket_client==1.8.0
 xxhash==3.5.0
 beautifulsoup4==4.12.3
 aiortc==1.10.0
+pyinstaller==6.17.0


### PR DESCRIPTION
## Summary
- Hide the macOS dock icon since the app already has a menu bar icon, allowing it to run seamlessly in the background
- Add native error dialog for startup crashes using `osascript` so users see errors instead of silent failures
- Add PyInstaller spec file for macOS builds with `LSUIElement: True` in Info.plist

## Changes
- **tray.py**: Use `NSApplicationActivationPolicyAccessory` via AppKit to hide dock icon after tkinter initialization
- **main.py**: Add `show_error_dialog()` function using native macOS `osascript` for startup error display
- **ClipCascade_macos.spec**: New PyInstaller spec file with `LSUIElement: True` and `tkinter` hidden import
- **requirements_mac.txt**: Add `pyinstaller` dependency
- **.gitignore**: Add build artifacts (`build/`, `dist/`, `.venv/`)

Fixes #101