### PR TITLE
fix(macOS): hide dock icon, run as menu-bar-only app

### DIFF
--- a/ClipCascade_Desktop/src/gui/tray.py
+++ b/ClipCascade_Desktop/src/gui/tray.py
@@ -47,6 +47,16 @@ class TaskbarPanel:
         self.root = tk.Tk()
         self.root.withdraw()  # Hide the root window
 
+        # Hide dock icon on macOS (menu bar only)
+        if PLATFORM == MACOS:
+            try:
+                import AppKit
+                AppKit.NSApp.setActivationPolicy_(
+                    AppKit.NSApplicationActivationPolicyAccessory
+                )
+            except Exception:
+                pass
+
         # Initial state: Connected
         self.is_connected = True
 


### PR DESCRIPTION
Fixes #101. Sets NSApplicationActivationPolicyAccessory after tk.Tk().withdraw() so ClipCascade runs as a menu-bar-only app on macOS. No dock icon, no Cmd+Tab entry. Wrapped in try/except — no-op on Windows/Linux. Tested on macOS Sequoia Apple Silicon.