### PR TITLE
3.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 private/
 screenshots/
+.DS_Store
+.vscode/

--- a/ClipCascade_Desktop/src/.gitignore
+++ b/ClipCascade_Desktop/src/.gitignore
@@ -1,3 +1,7 @@
 **/__pycache__/
 *.log
 DATA
+build/
+dist/
+*.spec.bak
+.venv/

--- a/ClipCascade_Desktop/src/ClipCascade_macos.spec
+++ b/ClipCascade_Desktop/src/ClipCascade_macos.spec
@@ -1,0 +1,49 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+import certifi
+
+a = Analysis(
+    ['main.py'],
+    pathex=[],
+    binaries=[],
+    datas=[(certifi.where(), 'certifi')],
+    hiddenimports=['tkinter'],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='ClipCascade',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=['../../logo/logo.icns'],
+)
+app = BUNDLE(
+    exe,
+    name='ClipCascade.app',
+    icon='../../logo/logo.icns',
+    bundle_identifier=None,
+    info_plist={
+        'LSUIElement': True,
+    },
+)

--- a/ClipCascade_Desktop/src/ClipCascade_win.spec
+++ b/ClipCascade_Desktop/src/ClipCascade_win.spec
@@ -1,0 +1,38 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+a = Analysis(
+    ['main.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=['plyer.platforms.win.notification'],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='ClipCascade',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=['../../logo/logo.ico'],
+)

--- a/ClipCascade_Desktop/src/cli/login.py
+++ b/ClipCascade_Desktop/src/cli/login.py
@@ -186,20 +186,24 @@ class LoginForm:
             )
             break
 
-        ssl_ca_bundle = (
-            input(
-                f"ssl ca bundle path (optional) [{self.config.data.get('ssl_ca_bundle') or ''}]: "
-            )
-            or (self.config.data.get("ssl_ca_bundle") or "")
-        ).strip()
-        if ssl_ca_bundle:
+        while True:
+            ssl_ca_bundle = (
+                input(
+                    f"ssl ca bundle path (optional) [{self.config.data.get('ssl_ca_bundle') or ''}]: "
+                )
+                or (self.config.data.get("ssl_ca_bundle") or "")
+            ).strip()
+            if ssl_ca_bundle == "":
+                self.config.data["ssl_ca_bundle"] = ""
+                break
             if not os.path.isfile(ssl_ca_bundle):
                 CustomDialog(
                     "Invalid Input\nSSL CA bundle path is not a file or does not exist.",
                     msg_type="error",
                 ).mainloop()
-                return
-        self.config.data["ssl_ca_bundle"] = ssl_ca_bundle
+                continue
+            self.config.data["ssl_ca_bundle"] = ssl_ca_bundle
+            break
 
         CustomDialog("Logging in...").mainloop()
 

--- a/ClipCascade_Desktop/src/cli/login.py
+++ b/ClipCascade_Desktop/src/cli/login.py
@@ -1,4 +1,5 @@
 import getpass
+import os
 import re
 
 from core.config import Config
@@ -13,7 +14,6 @@ class LoginForm:
         on_login_callback=None,
         on_quit_callback=None,
     ):
-        super().__init__()
         self.config = config
         self.on_login_callback = on_login_callback
         self.on_quit_callback = on_quit_callback
@@ -60,6 +60,21 @@ class LoginForm:
         self.config.data["server_url"] = LoginForm.remove_trailing_slash(
             server_url.strip()
         )
+
+        ssl_ca_bundle = (
+            input(
+                f"ssl ca bundle path (optional) [{self.config.data.get('ssl_ca_bundle') or ''}]: "
+            )
+            or (self.config.data.get("ssl_ca_bundle") or "")
+        ).strip()
+        if ssl_ca_bundle:
+            if not os.path.isfile(ssl_ca_bundle):
+                CustomDialog(
+                    "Invalid Input\nSSL CA bundle path is not a file or does not exist.",
+                    msg_type="error",
+                ).mainloop()
+                return
+        self.config.data["ssl_ca_bundle"] = ssl_ca_bundle
 
         self.config.data["cipher_enabled"] = LoginForm.str_to_bool(
             input(

--- a/ClipCascade_Desktop/src/cli/login.py
+++ b/ClipCascade_Desktop/src/cli/login.py
@@ -61,21 +61,6 @@ class LoginForm:
             server_url.strip()
         )
 
-        ssl_ca_bundle = (
-            input(
-                f"ssl ca bundle path (optional) [{self.config.data.get('ssl_ca_bundle') or ''}]: "
-            )
-            or (self.config.data.get("ssl_ca_bundle") or "")
-        ).strip()
-        if ssl_ca_bundle:
-            if not os.path.isfile(ssl_ca_bundle):
-                CustomDialog(
-                    "Invalid Input\nSSL CA bundle path is not a file or does not exist.",
-                    msg_type="error",
-                ).mainloop()
-                return
-        self.config.data["ssl_ca_bundle"] = ssl_ca_bundle
-
         self.config.data["cipher_enabled"] = LoginForm.str_to_bool(
             input(
                 f"enabled encryption(recommended) [{LoginForm.bool_to_str(self.config.data['cipher_enabled'])}]: "
@@ -200,6 +185,21 @@ class LoginForm:
                 default_file_download_location
             )
             break
+
+        ssl_ca_bundle = (
+            input(
+                f"ssl ca bundle path (optional) [{self.config.data.get('ssl_ca_bundle') or ''}]: "
+            )
+            or (self.config.data.get("ssl_ca_bundle") or "")
+        ).strip()
+        if ssl_ca_bundle:
+            if not os.path.isfile(ssl_ca_bundle):
+                CustomDialog(
+                    "Invalid Input\nSSL CA bundle path is not a file or does not exist.",
+                    msg_type="error",
+                ).mainloop()
+                return
+        self.config.data["ssl_ca_bundle"] = ssl_ca_bundle
 
         CustomDialog("Logging in...").mainloop()
 

--- a/ClipCascade_Desktop/src/clipboard/clipboard_manager.py
+++ b/ClipCascade_Desktop/src/clipboard/clipboard_manager.py
@@ -250,8 +250,7 @@ class ClipboardManager:
                         tiff_data = output.getvalue()
 
                     clipboard_monitor.enable_block_image_once()  # Block image copy to prevent deadlock
-                    pb_image = pasteboard.Pasteboard()
-                    pb_image.set_contents(tiff_data, pasteboard.TIFF)
+                    clipboard_monitor.write_to_pasteboard(tiff_data, pasteboard.TIFF)
                 elif PLATFORM.startswith(LINUX):
                     # Save the image to a binary buffer in PNG format
                     with io.BytesIO() as output:

--- a/ClipCascade_Desktop/src/clipboard/clipboard_manager.py
+++ b/ClipCascade_Desktop/src/clipboard/clipboard_manager.py
@@ -10,7 +10,7 @@ from PIL import Image
 from core.constants import *
 from core.config import Config
 
-if PLATFORM.startswith(LINUX) and not XMODE:
+if PLATFORM.startswith(LINUX) and LINUX_USE_CLI_UI:
     from cli.tray import TaskbarPanel
 else:
     from gui.tray import TaskbarPanel

--- a/ClipCascade_Desktop/src/clipboard/clipboard_monitor_linux.py
+++ b/ClipCascade_Desktop/src/clipboard/clipboard_monitor_linux.py
@@ -65,7 +65,10 @@ def _monitor_x_wl_clipboard(
         r"no suitable type of content copied",  # wl-clipboard pattern
     ]
 
-    if x_mode:
+    if LINUX_CLIPBOARD_POLL_INTERVAL_SEC is not None:
+        timeout = LINUX_CLIPBOARD_POLL_INTERVAL_SEC
+        logging.info(f"Clipboard polling interval (--polling): {timeout}s")
+    elif x_mode:
         timeout = 0.3  # xclip seconds
     else:
         timeout = 3  # wl-clipboard seconds

--- a/ClipCascade_Desktop/src/clipboard/clipboard_monitor_linux.py
+++ b/ClipCascade_Desktop/src/clipboard/clipboard_monitor_linux.py
@@ -13,6 +13,7 @@ _block_image_once = False
 
 _is_gdk_running = False
 _run_poll = threading.Event()
+_wl_watch_proc = None
 
 
 def _on_clipboard_changed(
@@ -179,6 +180,148 @@ def _monitor_x_wl_clipboard(
         time.sleep(timeout)
 
 
+def _monitor_wl_watch(enable_image_monitoring=False, enable_file_monitoring=False):
+    """Event-driven Wayland clipboard monitoring using wl-paste --watch.
+    Uses the wlr-data-control-v1 protocol which does not create visible
+    surfaces or steal focus. Supported by wlroots-based compositors
+    (Sway, Hyprland, etc.) and KDE Plasma on Wayland.
+    Returns True if watch mode ran successfully, False to fall back to polling."""
+    global _block_image_once, _wl_watch_proc
+
+    last_error = None
+    previous_clipboard = None
+    ignore_patterns = [
+        r"target .+ not available",
+        r"no suitable type of content copied",
+    ]
+
+    try:
+        _wl_watch_proc = subprocess.Popen(
+            ["wl-paste", "--watch", "echo"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        time.sleep(0.5)
+        if _wl_watch_proc.poll() is not None:
+            stderr_out = _wl_watch_proc.stderr.read().decode("utf-8", errors="ignore")
+            logging.warning(
+                f"wl-paste --watch exited immediately: {stderr_out.strip()}"
+            )
+            _wl_watch_proc = None
+            return False
+
+        logging.info(
+            "Using wl-paste --watch for clipboard monitoring (no focus stealing)"
+        )
+
+        while _run_poll.is_set():
+            line = _wl_watch_proc.stdout.readline()
+            if not line:
+                break
+            if not _run_poll.is_set():
+                break
+
+            success, mime_output = execute_command("wl-paste", "-l")
+            if not success:
+                error_msg = f"Failed to retrieve MIME types: {mime_output}"
+                if error_msg != last_error:
+                    logging.error(error_msg)
+                    last_error = error_msg
+                continue
+
+            mime_list = mime_output.decode("utf-8")
+            mime_list = mime_list.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+            mime_list = [m.strip() for m in mime_list if len(m.strip()) > 0]
+            type_ = convert_mime_to_generic_type(mime_list)
+
+            # Text
+            if type_ == "text":
+                success, text = execute_command("wl-paste", "-n")
+                if success:
+                    text = text.decode("utf-8")
+                    if len(text) > 0 and text != previous_clipboard:
+                        previous_clipboard = text
+                        if _callback_update:
+                            _callback_update("text", text)
+                else:
+                    error_msg = (
+                        f"Failed to retrieve text content from clipboard. {text}"
+                    )
+                    if error_msg != last_error:
+                        if not any(
+                            re.search(pattern, error_msg.lower())
+                            for pattern in ignore_patterns
+                        ):
+                            logging.error(error_msg)
+                        last_error = error_msg
+
+            # Image
+            elif type_ == "image" and enable_image_monitoring:
+                success, image = execute_command("wl-paste", "-t", "image/png")
+                if success:
+                    if image != previous_clipboard:
+                        previous_clipboard = image
+                        if _callback_update and not _block_image_once:
+                            _callback_update("image", image)
+                        else:
+                            _block_image_once = False
+                else:
+                    error_msg = (
+                        f"Failed to retrieve image content from clipboard. {image}"
+                    )
+                    if error_msg != last_error:
+                        if not any(
+                            re.search(pattern, error_msg.lower())
+                            for pattern in ignore_patterns
+                        ):
+                            logging.error(error_msg)
+                        last_error = error_msg
+
+            # Files
+            elif type_ == "files" and enable_file_monitoring:
+                success, files = execute_command(
+                    "wl-paste", "-t", "text/uri-list", "-n"
+                )
+                if success:
+                    files = files.decode("utf-8")
+                    files = (
+                        files.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+                    )
+                    files = [f.strip() for f in files if len(f.strip()) > 0]
+                    if files != previous_clipboard:
+                        previous_clipboard = files
+                        if _callback_update:
+                            _callback_update("files", files)
+                else:
+                    error_msg = (
+                        f"Failed to retrieve files content from clipboard. {files}"
+                    )
+                    if error_msg != last_error:
+                        if not any(
+                            re.search(pattern, error_msg.lower())
+                            for pattern in ignore_patterns
+                        ):
+                            logging.error(error_msg)
+                        last_error = error_msg
+
+        return True
+    except FileNotFoundError:
+        logging.warning("wl-paste not found, cannot use --watch mode")
+        return False
+    except Exception as e:
+        logging.warning(f"wl-paste --watch failed: {e}")
+        return False
+    finally:
+        if _wl_watch_proc is not None:
+            _wl_watch_proc.terminate()
+            try:
+                _wl_watch_proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                _wl_watch_proc.kill()
+            _wl_watch_proc = None
+
+
 def convert_mime_to_generic_type(mime_list):
     if "text/uri-list" in mime_list:
         return "files"
@@ -242,11 +385,18 @@ def _start_clipboard_polling(enable_image_monitoring, enable_file_monitoring):
             enable_file_monitoring=enable_file_monitoring,
         )
     else:
-        _monitor_x_wl_clipboard(
-            x_mode=XMODE,
+        if not _monitor_wl_watch(
             enable_image_monitoring=enable_image_monitoring,
             enable_file_monitoring=enable_file_monitoring,
-        )
+        ):
+            logging.info(
+                "Falling back to wl-paste polling mode for clipboard monitoring"
+            )
+            _monitor_x_wl_clipboard(
+                x_mode=False,
+                enable_image_monitoring=enable_image_monitoring,
+                enable_file_monitoring=enable_file_monitoring,
+            )
 
 
 def _runner(enable_image_monitoring=False, enable_file_monitoring=False):
@@ -293,7 +443,7 @@ def _start(enable_image_monitoring=False, enable_file_monitoring=False):
 
 
 def stop():
-    global _clipboard_thread, _callback_update, _block_image_once, _run_poll, _is_gdk_running
+    global _clipboard_thread, _callback_update, _block_image_once, _run_poll, _is_gdk_running, _wl_watch_proc
     if _clipboard_thread:
         if _is_gdk_running:
             import gi
@@ -304,10 +454,13 @@ def stop():
             Gtk.main_quit()
             _is_gdk_running = False
         _run_poll.clear()
+        if _wl_watch_proc is not None:
+            _wl_watch_proc.terminate()
         _clipboard_thread.join()  # Wait for the thread to finish
         _clipboard_thread = None
         _callback_update = None
         _block_image_once = False
+        _wl_watch_proc = None
         logging.info("Clipboard monitor stopped")
 
 

--- a/ClipCascade_Desktop/src/clipboard/clipboard_monitor_linux.py
+++ b/ClipCascade_Desktop/src/clipboard/clipboard_monitor_linux.py
@@ -68,7 +68,7 @@ def _monitor_x_wl_clipboard(
     if x_mode:
         timeout = 0.3  # xclip seconds
     else:
-        timeout = 1  # wl-clipboard seconds
+        timeout = 3  # wl-clipboard seconds
 
     while _run_poll.is_set():
         if x_mode:
@@ -401,6 +401,7 @@ def _start_clipboard_polling(enable_image_monitoring, enable_file_monitoring):
 
 def _runner(enable_image_monitoring=False, enable_file_monitoring=False):
     global _is_gdk_running, _run_poll
+    logging.info(f"XMODE: {XMODE}")
     try:
         _run_poll.set()
         import gi
@@ -410,6 +411,7 @@ def _runner(enable_image_monitoring=False, enable_file_monitoring=False):
         from gi.repository import Gtk, Gdk
 
         if "x11" in str(type(Gdk.Display.get_default())).lower():  # X11
+            logging.info("Starting GTK clipboard monitoring for X11 display server.")
             clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
             clipboard.connect(
                 "owner-change",

--- a/ClipCascade_Desktop/src/clipboard/clipboard_monitor_mac.py
+++ b/ClipCascade_Desktop/src/clipboard/clipboard_monitor_mac.py
@@ -9,6 +9,16 @@ _callback_update = None
 _run = False
 _first_run = False
 _block_image_once = False
+_pasteboard_lock = threading.Lock()
+_pb_writer = None
+
+
+def write_to_pasteboard(data, pb_type):
+    global _pb_writer
+    with _pasteboard_lock:
+        if _pb_writer is None:
+            _pb_writer = pasteboard.Pasteboard()
+        _pb_writer.set_contents(data, pb_type)
 
 
 def _runner(enable_image_monitoring=False, enable_file_monitoring=False):
@@ -27,7 +37,8 @@ def _runner(enable_image_monitoring=False, enable_file_monitoring=False):
 
             if enable_file_monitoring:
                 # Files
-                clipboard_files = pb_files.get_file_urls(diff=True)
+                with _pasteboard_lock:
+                    clipboard_files = pb_files.get_file_urls(diff=True)
                 if (
                     clipboard_files is not None
                     and type(clipboard_files) is tuple
@@ -38,10 +49,11 @@ def _runner(enable_image_monitoring=False, enable_file_monitoring=False):
                         _callback_update("files", clipboard_files)
 
             # Text
-            clipboard_text = pb_text.get_contents(
-                type=pasteboard.String, diff=True
-            )  # If True, retrieves and returns the content only if it has changed since the last call.
-            # This approach is efficient even in cases of frequent polling.
+            with _pasteboard_lock:
+                clipboard_text = pb_text.get_contents(
+                    type=pasteboard.String, diff=True
+                ) # If True, retrieves and returns the content only if it has changed since the last call.
+                # This approach is efficient even in cases of frequent polling.
             if (
                 clipboard_text is not None
                 and type(clipboard_text) is str
@@ -52,9 +64,10 @@ def _runner(enable_image_monitoring=False, enable_file_monitoring=False):
 
             if enable_image_monitoring:
                 # Image (PNG)
-                clipboard_image_png = pb_image_png.get_contents(
-                    type=pasteboard.PNG, diff=True
-                )
+                with _pasteboard_lock:
+                    clipboard_image_png = pb_image_png.get_contents(
+                        type=pasteboard.PNG, diff=True
+                    )
                 if (
                     clipboard_image_png is not None
                     and type(clipboard_image_png) is bytes
@@ -68,9 +81,10 @@ def _runner(enable_image_monitoring=False, enable_file_monitoring=False):
                                 _callback_update("image", clipboard_image_png)
 
                 # Image (TIFF)
-                clipboard_image_tiff = pb_image_tiff.get_contents(
-                    type=pasteboard.TIFF, diff=True
-                )
+                with _pasteboard_lock:
+                    clipboard_image_tiff = pb_image_tiff.get_contents(
+                        type=pasteboard.TIFF, diff=True
+                    )
                 if (
                     clipboard_image_tiff is not None
                     and type(clipboard_image_tiff) is bytes
@@ -106,7 +120,7 @@ def _start(enable_image_monitoring=False, enable_file_monitoring=False):
 
 
 def stop():
-    global _clipboard_thread, _callback_update, _run, _first_run, _block_image_once
+    global _clipboard_thread, _callback_update, _run, _first_run, _block_image_once, _pb_writer
     if _clipboard_thread:
         _run = False
         _clipboard_thread.join()  # Wait for the thread to finish
@@ -114,6 +128,7 @@ def stop():
         _clipboard_thread = None
         _callback_update = None
         _block_image_once = False
+        _pb_writer = None
         logging.info("Clipboard monitor stopped")
 
 

--- a/ClipCascade_Desktop/src/core/application.py
+++ b/ClipCascade_Desktop/src/core/application.py
@@ -16,7 +16,7 @@ elif PLATFORM == MACOS or PLATFORM.startswith(LINUX):
     import fcntl
 
 
-if PLATFORM.startswith(LINUX) and not XMODE:
+if PLATFORM.startswith(LINUX) and LINUX_USE_CLI_UI:
     import pyfiglet
     from cli.login import LoginForm
     from cli.info import CustomDialog
@@ -131,7 +131,7 @@ class Application:
         # enable login form
         used_saved_credentials = False
         display_login_success_dialog = False
-        if PLATFORM.startswith(LINUX) and not XMODE:
+        if PLATFORM.startswith(LINUX) and LINUX_USE_CLI_UI:
             Echo("═" * 14 + "\n║ LOGIN FORM ║\n" + "═" * 14)
         while True:
             if (
@@ -149,7 +149,7 @@ class Application:
                     self.config,
                     on_quit_callback=(
                         None
-                        if (PLATFORM.startswith(LINUX) and not XMODE)
+                        if (PLATFORM.startswith(LINUX) and LINUX_USE_CLI_UI)
                         else lambda: sys.exit(0)
                     ),
                 )
@@ -205,7 +205,7 @@ class Application:
                 CustomDialog("Login Failed\n" + msg_login, msg_type="error").mainloop()
 
             raw_password = None  # Clear the raw password
-            if PLATFORM.startswith(LINUX) and not XMODE:
+            if PLATFORM.startswith(LINUX) and LINUX_USE_CLI_UI:
                 Echo("-" * 53)
 
     def _get_ws_manager(self):
@@ -230,7 +230,7 @@ class Application:
             elif PLATFORM == MACOS:
                 key = "macos"
             elif PLATFORM.startswith(LINUX):
-                if XMODE:
+                if not LINUX_USE_CLI_UI:
                     key = "linux_gui"
                 else:
                     key = "linux_non_gui"
@@ -264,7 +264,7 @@ class Application:
             raise Exception(f"Error during logging off: {e}")
 
     def banner(self):
-        if PLATFORM.startswith(LINUX) and not XMODE:
+        if PLATFORM.startswith(LINUX) and LINUX_USE_CLI_UI:
             Echo(pyfiglet.figlet_format(APP_NAME))
             Echo("*" * 53)
             Echo("Real-Time Clipboard Syncing".center(53))

--- a/ClipCascade_Desktop/src/core/config.py
+++ b/ClipCascade_Desktop/src/core/config.py
@@ -28,6 +28,7 @@ class Config:
             "default_file_download_location": "",
             "server_mode": "P2S",
             "stun_url": "",
+            "ssl_ca_bundle": "",
         }
 
     def save(self):

--- a/ClipCascade_Desktop/src/core/constants.py
+++ b/ClipCascade_Desktop/src/core/constants.py
@@ -182,6 +182,8 @@ WEBSOCKET_TIMEOUT = 3000  # milliseconds
 # P2P signaling WebSocket keepalive (RFC 6455 ping/pong).
 P2P_WS_PING_INTERVAL_SEC = 25
 P2P_WS_PING_TIMEOUT_SEC = 20
+# Data-channel keepalive (JSON envelope with _cc_keepalive); helps idle sessions and mobile radios.
+P2P_DC_HEARTBEAT_INTERVAL_SEC = 20
 # After sleep, aiortc RTCPeerConnection.close() can block; cap wait so the asyncio
 # thread does not stall (which would also block processing ASSIGNED_ID / PEER_LIST).
 P2P_PC_CLOSE_TIMEOUT_SEC = 5.0

--- a/ClipCascade_Desktop/src/core/constants.py
+++ b/ClipCascade_Desktop/src/core/constants.py
@@ -55,7 +55,83 @@ def detect_linux_display_server():
     return "Unknown"
 
 
+def _parse_linux_bool_flag_token(raw):
+    if raw is None or not str(raw).strip():
+        raise ValueError("empty value")
+    s = str(raw).strip().lower()
+    if s == "true":
+        return True
+    if s == "false":
+        return False
+    raise ValueError(raw)
+
+
+def _parse_linux_positive_float(raw):
+    if raw is None or not str(raw).strip():
+        raise ValueError("empty value")
+    try:
+        value = float(str(raw).strip())
+    except ValueError:
+        raise ValueError(f"not a number: {raw!r}")
+    if value <= 0:
+        raise ValueError("must be a positive number")
+    return value
+
+
+def _strip_linux_cli_overrides(argv):
+    """
+    Linux-only: parse --gui / --xmode (true|false), --polling (seconds), remove them from argv.
+    Last occurrence wins if a flag is repeated.
+    """
+    gui_override = None
+    xmode_override = None
+    polling_override = None
+    i = 1
+    kept = [argv[0]] if argv else []
+    while i < len(argv):
+        item = argv[i]
+        if item.startswith("--gui="):
+            gui_override = _parse_linux_bool_flag_token(item.split("=", 1)[1])
+            i += 1
+            continue
+        if item == "--gui":
+            if i + 1 >= len(argv):
+                raise ValueError("--gui requires true or false")
+            gui_override = _parse_linux_bool_flag_token(argv[i + 1])
+            i += 2
+            continue
+        if item.startswith("--xmode="):
+            xmode_override = _parse_linux_bool_flag_token(item.split("=", 1)[1])
+            i += 1
+            continue
+        if item == "--xmode":
+            if i + 1 >= len(argv):
+                raise ValueError("--xmode requires true or false")
+            xmode_override = _parse_linux_bool_flag_token(argv[i + 1])
+            i += 2
+            continue
+        if item.startswith("--polling="):
+            polling_override = _parse_linux_positive_float(item.split("=", 1)[1])
+            i += 1
+            continue
+        if item == "--polling":
+            if i + 1 >= len(argv):
+                raise ValueError("--polling requires a positive number (seconds)")
+            polling_override = _parse_linux_positive_float(argv[i + 1])
+            i += 2
+            continue
+        kept.append(item)
+        i += 1
+    argv[:] = kept
+    return gui_override, xmode_override, polling_override
+
+
 PLATFORM = get_os_and_display_server()
+
+# Linux: CLI UI vs GTK tray — False on other platforms (unused except behind LINUX checks).
+LINUX_USE_CLI_UI = False
+# Linux: optional override for xclip/wl-paste polling sleep (seconds); None = use built-ins (0.3 / 3).
+LINUX_CLIPBOARD_POLL_INTERVAL_SEC = None
 
 if PLATFORM.startswith(LINUX):
     if (
@@ -66,6 +142,25 @@ if PLATFORM.startswith(LINUX):
         XMODE = True
     else:
         XMODE = False
+
+    try:
+        gui_override, xmode_override, polling_override = _strip_linux_cli_overrides(
+            sys.argv
+        )
+    except ValueError as e:
+        print(f"clipcascade (Linux CLI): {e}", file=sys.stderr)
+        sys.exit(2)
+
+    if xmode_override is not None:
+        XMODE = xmode_override
+
+    if gui_override is not None:
+        LINUX_USE_CLI_UI = not gui_override
+    else:
+        LINUX_USE_CLI_UI = not XMODE
+
+    if polling_override is not None:
+        LINUX_CLIPBOARD_POLL_INTERVAL_SEC = polling_override
 
 
 # App version

--- a/ClipCascade_Desktop/src/core/constants.py
+++ b/ClipCascade_Desktop/src/core/constants.py
@@ -83,6 +83,14 @@ elif PLATFORM.startswith(LINUX):
 # core constants
 RECONNECT_WS_TIMER = 10  # seconds
 WEBSOCKET_TIMEOUT = 3000  # milliseconds
+
+# P2P signaling WebSocket keepalive (RFC 6455 ping/pong).
+P2P_WS_PING_INTERVAL_SEC = 25
+P2P_WS_PING_TIMEOUT_SEC = 20
+# After sleep, aiortc RTCPeerConnection.close() can block; cap wait so the asyncio
+# thread does not stall (which would also block processing ASSIGNED_ID / PEER_LIST).
+P2P_PC_CLOSE_TIMEOUT_SEC = 5.0
+
 LOG_FILE_NAME = "clipcascade_log.log"
 LOG_LEVEL = logging.INFO  # Use valid levels: DEBUG, INFO, WARNING, ERROR, CRITICAL
 DATA_FILE_NAME = "DATA"
@@ -99,16 +107,12 @@ WEBSOCKET_ENDPOINT = "/clipsocket"
 WEBSOCKET_ENDPOINT_P2P = "/p2psignaling"
 STUN_URL = "/stun-url"
 
-VERSION_URL = (
-    "https://raw.githubusercontent.com/Sathvik-Rao/ClipCascade/main/version.json"
-)
+VERSION_URL = "https://raw.githubusercontent.com/Sathvik-Rao/ClipCascade/main/version.json"
 RELEASE_URL = "https://github.com/Sathvik-Rao/ClipCascade/releases/latest"
 GITHUB_URL = "https://github.com/Sathvik-Rao/ClipCascade"
 APP_NAME = "ClipCascade"
 HELP_URL = f"{GITHUB_URL}/blob/main/README.md"
-METADATA_URL = (
-    "https://raw.githubusercontent.com/Sathvik-Rao/ClipCascade/main/metadata.json"
-)
+METADATA_URL = "https://raw.githubusercontent.com/Sathvik-Rao/ClipCascade/main/metadata.json"
 
 if PLATFORM == WINDOWS:
     MUTEX_NAME = "Global\\ClipCascade_Mutex_PSSR"

--- a/ClipCascade_Desktop/src/core/constants.py
+++ b/ClipCascade_Desktop/src/core/constants.py
@@ -70,14 +70,14 @@ if PLATFORM.startswith(LINUX):
 
 # App version
 if PLATFORM == WINDOWS:
-    APP_VERSION = "3.0.0"
+    APP_VERSION = "3.2.0"
 elif PLATFORM == MACOS:
-    APP_VERSION = "3.0.0"
+    APP_VERSION = "3.2.0"
 elif PLATFORM.startswith(LINUX):
     if XMODE:
-        APP_VERSION = "3.0.0"  # gui version
+        APP_VERSION = "3.2.0"  # gui version
     else:
-        APP_VERSION = "3.0.0"  # non-gui(cli) version
+        APP_VERSION = "3.2.0"  # non-gui(cli) version
 
 
 # core constants

--- a/ClipCascade_Desktop/src/gui/info.py
+++ b/ClipCascade_Desktop/src/gui/info.py
@@ -5,6 +5,7 @@ import gc
 import time
 
 from utils.window_manager import center_window
+from core.constants import *
 
 
 class CustomDialog(tk.Tk):
@@ -47,6 +48,9 @@ class CustomDialog(tk.Tk):
         self.attributes("-topmost", True)
         self.resizable(False, False)
         self.focus_force()
+
+        if PLATFORM == MACOS:
+            self.after(100, self._macos_restore_focus)
 
     def _show_dialog(self):
         """Display the appropriate dialog based on the message type."""
@@ -95,6 +99,17 @@ class CustomDialog(tk.Tk):
         ok_button = ttk.Button(button_frame, text="OK", command=self.close, width=10)
         ok_button.pack()
         ok_button.focus_set()
+
+    def _macos_restore_focus(self):
+        """Force macOS to properly activate and focus the dialog."""
+        try:
+            from AppKit import NSApplication
+            app = NSApplication.sharedApplication()
+            app.activateIgnoringOtherApps_(True)
+        except ImportError:
+            pass
+        self.lift()
+        self.focus_force()
 
     def close(self):
         if self.after_id:

--- a/ClipCascade_Desktop/src/gui/info.py
+++ b/ClipCascade_Desktop/src/gui/info.py
@@ -36,7 +36,12 @@ class CustomDialog(tk.Tk):
     def _configure_window(self):
         """Configure the dialog window properties."""
         self.title("ClipCascade")
-        self.geometry("600x300")
+        self.geometry(
+            "600x300+{}+{}".format(
+                (self.winfo_screenwidth() - 600) // 2,
+                (self.winfo_screenheight() - 300) // 2,
+            )
+        )
         self.update_idletasks()
         center_window(self)
         self.attributes("-topmost", True)
@@ -66,9 +71,7 @@ class CustomDialog(tk.Tk):
         )
         symbol_label.pack(side="left", padx=(0, 10))
 
-        title_label = ttk.Label(
-            title_frame, text=title, style="Header.TLabel", foreground=color
-        )
+        title_label = ttk.Label(title_frame, text=title, style="Header.TLabel", foreground=color)
         title_label.pack(side="left")
 
         # Message frame for scrolled text

--- a/ClipCascade_Desktop/src/gui/info.py
+++ b/ClipCascade_Desktop/src/gui/info.py
@@ -4,6 +4,8 @@ from tkinter import scrolledtext
 import gc
 import time
 
+from utils.window_manager import center_window
+
 
 class CustomDialog(tk.Tk):
     def __init__(self, message, msg_type="info", timeout=None):
@@ -34,12 +36,9 @@ class CustomDialog(tk.Tk):
     def _configure_window(self):
         """Configure the dialog window properties."""
         self.title("ClipCascade")
-        self.geometry(
-            "600x300+{}+{}".format(
-                (self.winfo_screenwidth() - 600) // 2,
-                (self.winfo_screenheight() - 300) // 2,
-            )
-        )
+        self.geometry("600x300")
+        self.update_idletasks()
+        center_window(self)
         self.attributes("-topmost", True)
         self.resizable(False, False)
         self.focus_force()

--- a/ClipCascade_Desktop/src/gui/login.py
+++ b/ClipCascade_Desktop/src/gui/login.py
@@ -125,10 +125,12 @@ class LoginForm(tk.Tk):
 
         # Extra Configurations Toggle Label
         self.show_extra = False  # State to track visibility
+        self.toggle_normal_color = "#007acc"  # neutral blue with strong contrast
+        self.toggle_hover_color = "#005a9e"   # slightly darker for hover feedback
         self.toggle_label = tk.Label(
             main_frame,
             text="Enable Extra Config",
-            fg="blue",
+            fg=self.toggle_normal_color,
             cursor="hand2",
             font=font.Font(family="Helvetica", size=13, underline=True),
         )
@@ -332,11 +334,11 @@ class LoginForm(tk.Tk):
 
     def _on_hover(self, event=None):
         """Change text color on hover."""
-        self.toggle_label.config(fg="dark blue")
+        self.toggle_label.config(fg=self.toggle_hover_color)
 
     def _on_leave(self, event=None):
         """Revert text color when not hovered."""
-        self.toggle_label.config(fg="blue")
+        self.toggle_label.config(fg=self.toggle_normal_color)
 
     def _bind_mousewheel(self):
         """Bind mouse wheel events to the canvas for scrolling."""

--- a/ClipCascade_Desktop/src/gui/login.py
+++ b/ClipCascade_Desktop/src/gui/login.py
@@ -3,7 +3,9 @@ import tkinter as tk
 from tkinter import ttk, font
 import gc
 import time
+import os
 
+from utils.window_manager import center_window
 from core.config import Config
 from gui.info import CustomDialog
 from core.constants import *
@@ -294,32 +296,16 @@ class LoginForm(tk.Tk):
         # Set a maximum height for the window
         self.max_window_height = 600
 
-        # Center the window on the screen
-        self._center_window()
-
         # on press enter key
         self.bind("<Return>", lambda event: self.on_login())
 
-        self.deiconify()  # Show the root window
-
-    def _center_window(self):
-        """Centers the window on the screen based on its current size."""
-        self.update_idletasks()  # Ensure accurate dimensions
-        window_width = self.winfo_width()
-        window_height = self.winfo_height()
-        screen_width = self.winfo_screenwidth()
-        screen_height = self.winfo_screenheight()
-
-        # Calculate position
-        x = (screen_width // 2) - (window_width // 2)
-        y = (screen_height // 2) - (window_height // 2)
-
-        # Enforce maximum height if needed
-        if window_height > self.max_window_height:
-            window_height = self.max_window_height
-
-        # Always set geometry to the current (or adjusted) size and center it
-        self.geometry(f"{window_width}x{window_height}+{x}+{y}")
+        self.deiconify()  # Show window
+        self.update_idletasks()
+        center_window(self, self.max_window_height)
+        
+        # Drop always-on-top after showing
+        self.after(300, lambda: self.attributes("-topmost", False))
+        
 
     def _toggle_password(self, event=None):
         if self.password_entry.cget("show") == "*":
@@ -342,7 +328,7 @@ class LoginForm(tk.Tk):
         self.update_idletasks()
         self.geometry("")
         self.update_idletasks()
-        self._center_window()
+        center_window(self)
 
     def _on_hover(self, event=None):
         """Change text color on hover."""

--- a/ClipCascade_Desktop/src/gui/login.py
+++ b/ClipCascade_Desktop/src/gui/login.py
@@ -11,6 +11,51 @@ from gui.info import CustomDialog
 from core.constants import *
 
 
+class HoverTooltip:
+    """Simple hover tooltip for Tk widgets."""
+
+    def __init__(self, widget, text, wraplength=520):
+        self.widget = widget
+        self.text = text
+        self.wraplength = wraplength
+        self.tooltip_window = None
+        self.widget.bind("<Enter>", self._show, add="+")
+        self.widget.bind("<Leave>", self._hide, add="+")
+        self.widget.bind("<ButtonPress>", self._hide, add="+")
+
+    def _show(self, _event=None):
+        if self.tooltip_window or not self.text.strip():
+            return
+
+        # Position tooltip near the widget with an offset.
+        x = self.widget.winfo_rootx() + 18
+        y = self.widget.winfo_rooty() + self.widget.winfo_height() + 8
+
+        self.tooltip_window = tw = tk.Toplevel(self.widget)
+        tw.wm_overrideredirect(True)
+        tw.wm_geometry(f"+{x}+{y}")
+
+        label = tk.Label(
+            tw,
+            text=self.text,
+            justify=tk.LEFT,
+            relief=tk.SOLID,
+            borderwidth=1,
+            background="#ffffe0",
+            foreground="#202020",
+            font=("Helvetica", 10),
+            wraplength=self.wraplength,
+            padx=8,
+            pady=6,
+        )
+        label.pack()
+
+    def _hide(self, _event=None):
+        if self.tooltip_window:
+            self.tooltip_window.destroy()
+            self.tooltip_window = None
+
+
 class LoginForm(tk.Tk):
     def __init__(
         self,
@@ -30,6 +75,7 @@ class LoginForm(tk.Tk):
 
         self.withdraw()  # Hide the root window
         self.title("ClipCascade")
+        self._tooltips = []
 
         # Make the window appear on top and grab focus
         self.attributes("-topmost", True)
@@ -66,6 +112,11 @@ class LoginForm(tk.Tk):
         self.username_entry = ttk.Entry(self.field_frame, width=50, font=("Helvetica", 13))
         self.username_entry.insert(0, self.config.data["username"])
         self.username_entry.grid(row=0, column=1, padx=10, pady=5, sticky=tk.W + tk.E)
+        self._add_tooltip(
+            [user_label, self.username_entry],
+            "Username used to log in to your ClipCascade account.\n\n"
+            "Use the same account name on all devices that should share clipboard data.",
+        )
 
         # Password
         pass_label = ttk.Label(self.field_frame, text="Password:")
@@ -83,6 +134,12 @@ class LoginForm(tk.Tk):
         )
         self.eye_icon.pack(side=tk.RIGHT, padx=(5, 0))
         self.eye_icon.bind("<Button-1>", self._toggle_password)
+        self._add_tooltip(
+            [pass_label, self.password_entry, self.eye_icon],
+            "Account password used for server authentication.\n\n"
+            "If encryption is enabled, this password is also used to derive your encryption key.\n"
+            "Use the same password on all devices for successful decrypt/sync.",
+        )
 
         # Server URL
         server_label = ttk.Label(self.field_frame, text="Server URL:")
@@ -90,6 +147,15 @@ class LoginForm(tk.Tk):
         self.server_url_entry = ttk.Entry(self.field_frame, width=50, font=("Helvetica", 13))
         self.server_url_entry.insert(0, self.config.data["server_url"])
         self.server_url_entry.grid(row=2, column=1, padx=10, pady=5, sticky=tk.W + tk.E)
+        self._add_tooltip(
+            [server_label, self.server_url_entry],
+            "Address of your ClipCascade server.\n\n"
+            "Examples:\n"
+            "- Local server: http://localhost:8080\n"
+            "- LAN server: http://192.168.1.50:8080\n"
+            "- Reverse proxy/domain: https://clipcascade.example.com\n\n"
+            "Include protocol (http/https). Do not add /login or /clipsocket.",
+        )
 
         # Configure grid weights to ensure entries expand
         self.field_frame.columnconfigure(1, weight=1)
@@ -107,6 +173,13 @@ class LoginForm(tk.Tk):
             takefocus=False,
         )
         self.cipher_checkbox.pack(pady=3, anchor=tk.W)
+        self._add_tooltip(
+            [self.cipher_checkbox],
+            "Enables end-to-end encryption for clipboard content (recommended).\n\n"
+            "When enabled, clipboard data is encrypted on-device before sending.\n"
+            "All devices in the same account must use the same encryption settings "
+            "(password, salt, and hash rounds) to decrypt data correctly.",
+        )
 
         # Notification Checkbox
         self.notification_var = tk.BooleanVar(value=self.config.data["notification"])
@@ -117,6 +190,12 @@ class LoginForm(tk.Tk):
             takefocus=False,
         )
         self.notification_checkbox.pack(pady=3, anchor=tk.W)
+        self._add_tooltip(
+            [self.notification_checkbox],
+            "Shows local notifications for connection status events.\n\n"
+            "Useful to know when WebSocket disconnects/reconnects happen.\n"
+            "Turn this off if you prefer a quieter experience with fewer popups.",
+        )
 
         # Button frame
         button_frame = ttk.Frame(main_frame)
@@ -140,6 +219,11 @@ class LoginForm(tk.Tk):
         )
         self.toggle_label.pack(pady=(5, 10))
         self.toggle_label.bind("<Button-1>", self._toggle_extra_config)
+        self._add_tooltip(
+            [self.toggle_label],
+            "Shows advanced settings for encryption and clipboard behavior.\n\n"
+            "Most users can keep defaults. Open this section only if you need custom tuning.",
+        )
 
         # hover effects for the toggle label
         self.toggle_label.bind("<Enter>", self._on_hover)
@@ -192,6 +276,13 @@ class LoginForm(tk.Tk):
         self.hash_rounds_entry = ttk.Entry(self.extra_frame, width=50, font=("Helvetica", 13))
         self.hash_rounds_entry.insert(0, str(self.config.data["hash_rounds"]))
         self.hash_rounds_entry.grid(row=0, column=1, padx=10, pady=5, sticky=tk.W + tk.E)
+        self._add_tooltip(
+            [hash_rounds_label, self.hash_rounds_entry],
+            "Number of hash iterations used for encryption key derivation.\n\n"
+            "Higher value = stronger brute-force resistance, but slower processing.\n"
+            "Default is tuned for balance. Keep default unless you know why to change.\n"
+            "Must be a positive integer and must match on every device.",
+        )
 
         # Salt
         salt_label = ttk.Label(self.extra_frame, text="Salt:")
@@ -199,6 +290,14 @@ class LoginForm(tk.Tk):
         self.salt_entry = ttk.Entry(self.extra_frame, width=50, font=("Helvetica", 13))
         self.salt_entry.insert(0, self.config.data["salt"])
         self.salt_entry.grid(row=1, column=1, padx=10, pady=5, sticky=tk.W + tk.E)
+        self._add_tooltip(
+            [salt_label, self.salt_entry],
+            "Optional extra text mixed into encryption key generation.\n\n"
+            "It can be any combination of letters and numbers (you can also include symbols/spaces if desired).\n"
+            "Use the same exact salt on all devices if encryption is enabled.\n"
+            "If left blank, encryption still works using password + hash rounds.\n"
+            "Changing salt later will prevent old devices from decrypting new clipboard data.",
+        )
 
         # Save Password Locally Checkbox
         save_password_label = ttk.Label(
@@ -213,6 +312,12 @@ class LoginForm(tk.Tk):
             takefocus=False,
         )
         self.save_password_checkbox.grid(row=2, column=1, padx=10, pady=5, sticky=tk.W)
+        self._add_tooltip(
+            [save_password_label, self.save_password_checkbox],
+            "Stores your plain password locally for automatic login convenience.\n\n"
+            "Security trade-off: avoid this on shared or untrusted machines.\n"
+            "This only works when encryption is disabled.",
+        )
 
         # Maximum Clipboard Size - Local Limit
         local_clipboard_size_label = ttk.Label(
@@ -226,6 +331,14 @@ class LoginForm(tk.Tk):
             0, str(self.config.data["max_clipboard_size_local_limit_bytes"] or "")
         )
         self.local_clipboard_size_entry.grid(row=3, column=1, padx=10, pady=5, sticky=tk.W + tk.E)
+        self._add_tooltip(
+            [local_clipboard_size_label, self.local_clipboard_size_entry],
+            "Optional local safety limit for clipboard payload size (incoming and outgoing) in bytes.\n\n"
+            "Example: 1 MiB = 1048576 bytes.\n"
+            "Leave empty for no local limit.\n"
+            "Use a lower value if your device struggles with very large clipboard data "
+            "(large text/images/files). Must be a positive integer.",
+        )
 
         # Enable Image Sharing Checkbox
         enable_image_sharing_label = ttk.Label(self.extra_frame, text="Enable Image Sharing:")
@@ -239,6 +352,11 @@ class LoginForm(tk.Tk):
             takefocus=False,
         )
         self.enable_image_sharing_checkbox.grid(row=4, column=1, padx=10, pady=5, sticky=tk.W)
+        self._add_tooltip(
+            [enable_image_sharing_label, self.enable_image_sharing_checkbox],
+            "Controls whether this device sends copied images to other devices.\n\n"
+            "If disabled, this device can still receive images sent from other devices.",
+        )
 
         # Enable File Sharing Checkbox
         enable_file_sharing_label = ttk.Label(self.extra_frame, text="Enable File Sharing:")
@@ -250,6 +368,11 @@ class LoginForm(tk.Tk):
             takefocus=False,
         )
         self.enable_file_sharing_checkbox.grid(row=5, column=1, padx=10, pady=5, sticky=tk.W)
+        self._add_tooltip(
+            [enable_file_sharing_label, self.enable_file_sharing_checkbox],
+            "Controls whether this device sends copied/shared files to other devices.\n\n"
+            "If disabled, this device can still receive files sent from other devices.",
+        )
 
         # Default File Download Location
         default_file_download_location_label = ttk.Label(
@@ -266,6 +389,15 @@ class LoginForm(tk.Tk):
         )
         self.default_file_download_location_entry.grid(
             row=6, column=1, padx=10, pady=5, sticky=tk.W + tk.E
+        )
+        self._add_tooltip(
+            [default_file_download_location_label, self.default_file_download_location_entry],
+            "Optional default folder to save incoming files automatically.\n\n"
+            "Examples:\n"
+            "- Windows: C:\\Users\\YourName\\Downloads\n"
+            "- macOS/Linux: /Users/yourname/Downloads\n\n"
+            "Leave blank to choose a location manually when downloading files.\n"
+            "Path must already exist on this device.",
         )
 
         # Configure grid weights for extra_frame
@@ -309,6 +441,10 @@ class LoginForm(tk.Tk):
         )
         for w in extra_entries:
             w.configure(takefocus=bool(self.show_extra))
+
+    def _add_tooltip(self, widgets, text):
+        for widget in widgets:
+            self._tooltips.append(HoverTooltip(widget, text))
 
     def _macos_restore_focus(self):
         """Force macOS to properly activate and focus the window.

--- a/ClipCascade_Desktop/src/gui/login.py
+++ b/ClipCascade_Desktop/src/gui/login.py
@@ -274,6 +274,22 @@ class LoginForm(tk.Tk):
         # Drop always-on-top after showing
         self.after(300, lambda: self.attributes("-topmost", False))
 
+        if PLATFORM == MACOS:
+            self.after(400, self._macos_restore_focus)
+
+    def _macos_restore_focus(self):
+        """Force macOS to properly activate and focus the window.
+        Needed after sequential tk.Tk() creation/destruction cycles."""
+        try:
+            from AppKit import NSApplication
+            app = NSApplication.sharedApplication()
+            app.activateIgnoringOtherApps_(True)
+        except ImportError:
+            pass
+        self.lift()
+        self.focus_force()
+        self.username_entry.focus_set()
+
     def _toggle_password(self, event=None):
         if self.password_entry.cget("show") == "*":
             self.password_entry.config(show="")

--- a/ClipCascade_Desktop/src/gui/login.py
+++ b/ClipCascade_Desktop/src/gui/login.py
@@ -206,12 +206,13 @@ class LoginForm(tk.Tk):
         self.login_button.pack()
 
         # Extra Configurations Toggle Label
-        self.show_extra = False  # State to track visibility
+        # macOS: show advanced fields by default
+        self.show_extra = PLATFORM == MACOS
         self.toggle_normal_color = "#007acc"  # neutral blue with strong contrast
         self.toggle_hover_color = "#005a9e"  # slightly darker for hover feedback
         self.toggle_label = tk.Label(
             main_frame,
-            text="Enable Extra Config",
+            text="Hide Extra Config" if PLATFORM == MACOS else "Enable Extra Config",
             fg=self.toggle_normal_color,
             cursor="hand2",
             font=font.Font(family="Helvetica", size=13, underline=True),
@@ -231,8 +232,10 @@ class LoginForm(tk.Tk):
 
         # Extra Configuration Frame with Scrollbar
         self.extra_frame_container = ttk.Frame(main_frame)
-        # Initially hide the extra configuration frame
-        self.extra_frame_container.pack_forget()
+        if PLATFORM == MACOS:
+            self.extra_frame_container.pack(fill=tk.BOTH, expand=True)
+        else:
+            self.extra_frame_container.pack_forget()
 
         # Create a canvas inside the extra_frame_container
         self.extra_canvas = tk.Canvas(
@@ -400,6 +403,24 @@ class LoginForm(tk.Tk):
             "Path must already exist on this device.",
         )
 
+        # SSL CA bundle (private / corporate PKI)
+        ssl_ca_label = ttk.Label(self.extra_frame, text="SSL CA bundle (optional):")
+        ssl_ca_label.grid(row=7, column=0, padx=(0, 10), pady=5, sticky=tk.W)
+        self.ssl_ca_bundle_entry = ttk.Entry(
+            self.extra_frame, width=50, font=("Helvetica", 13)
+        )
+        self.ssl_ca_bundle_entry.insert(
+            0, self.config.data.get("ssl_ca_bundle") or ""
+        )
+        self.ssl_ca_bundle_entry.grid(row=7, column=1, padx=10, pady=5, sticky=tk.W + tk.E)
+        self._add_tooltip(
+            [ssl_ca_label, self.ssl_ca_bundle_entry],
+            "Path to a PEM file that contains your root CA (or full chain) for HTTPS/WSS.\n\n"
+            "Leave empty for default verification (public CAs / OS defaults).\n"
+            "Use this when your server uses a certificate from a private or internal CA.\n\n"
+            "Example: /etc/ssl/corp-root.pem or C:\\\\certs\\\\corp-root.pem",
+        )
+
         # Configure grid weights for extra_frame
         self.extra_frame.columnconfigure(1, weight=1)
 
@@ -438,6 +459,7 @@ class LoginForm(tk.Tk):
             self.salt_entry,
             self.local_clipboard_size_entry,
             self.default_file_download_location_entry,
+            self.ssl_ca_bundle_entry,
         )
         for w in extra_entries:
             w.configure(takefocus=bool(self.show_extra))
@@ -474,6 +496,7 @@ class LoginForm(tk.Tk):
             self.salt_entry,
             self.local_clipboard_size_entry,
             self.default_file_download_location_entry,
+            self.ssl_ca_bundle_entry,
         )
         if self.show_extra:
             focused = self.focus_get()
@@ -597,6 +620,16 @@ class LoginForm(tk.Tk):
                 ).mainloop()
                 return  # retry login
             self.config.data["default_file_download_location"] = default_file_download_location
+
+        ssl_ca_bundle = self.ssl_ca_bundle_entry.get().strip()
+        if ssl_ca_bundle:
+            if not os.path.isfile(ssl_ca_bundle):
+                CustomDialog(
+                    "Invalid Input\nSSL CA bundle path is not a file or does not exist.",
+                    msg_type="error",
+                ).mainloop()
+                return
+        self.config.data["ssl_ca_bundle"] = ssl_ca_bundle
 
         # call login callback
         if self.on_login_callback:

--- a/ClipCascade_Desktop/src/gui/login.py
+++ b/ClipCascade_Desktop/src/gui/login.py
@@ -48,9 +48,7 @@ class LoginForm(tk.Tk):
         main_frame.pack(fill=tk.BOTH, expand=True)
 
         # Title Label
-        title_label = ttk.Label(
-            main_frame, text="Please Log In", font=("Helvetica", 16, "bold")
-        )
+        title_label = ttk.Label(main_frame, text="Please Log In", font=("Helvetica", 16, "bold"))
         title_label.pack(pady=(0, 10))
 
         # Create a frame for the fields
@@ -60,9 +58,7 @@ class LoginForm(tk.Tk):
         # Username
         user_label = ttk.Label(self.field_frame, text="Username:")
         user_label.grid(row=0, column=0, padx=(0, 10), pady=5, sticky=tk.W)
-        self.username_entry = ttk.Entry(
-            self.field_frame, width=50, font=("Helvetica", 13)
-        )
+        self.username_entry = ttk.Entry(self.field_frame, width=50, font=("Helvetica", 13))
         self.username_entry.insert(0, self.config.data["username"])
         self.username_entry.grid(row=0, column=1, padx=10, pady=5, sticky=tk.W + tk.E)
 
@@ -84,9 +80,7 @@ class LoginForm(tk.Tk):
         # Server URL
         server_label = ttk.Label(self.field_frame, text="Server URL:")
         server_label.grid(row=2, column=0, padx=(0, 10), pady=5, sticky=tk.W)
-        self.server_url_entry = ttk.Entry(
-            self.field_frame, width=50, font=("Helvetica", 13)
-        )
+        self.server_url_entry = ttk.Entry(self.field_frame, width=50, font=("Helvetica", 13))
         self.server_url_entry.insert(0, self.config.data["server_url"])
         self.server_url_entry.grid(row=2, column=1, padx=10, pady=5, sticky=tk.W + tk.E)
 
@@ -118,15 +112,13 @@ class LoginForm(tk.Tk):
         button_frame.pack(pady=(10, 0))
 
         # Login Button
-        self.login_button = ttk.Button(
-            button_frame, text="Login", command=self.on_login
-        )
+        self.login_button = ttk.Button(button_frame, text="Login", command=self.on_login)
         self.login_button.pack()
 
         # Extra Configurations Toggle Label
         self.show_extra = False  # State to track visibility
         self.toggle_normal_color = "#007acc"  # neutral blue with strong contrast
-        self.toggle_hover_color = "#005a9e"   # slightly darker for hover feedback
+        self.toggle_hover_color = "#005a9e"  # slightly darker for hover feedback
         self.toggle_label = tk.Label(
             main_frame,
             text="Enable Extra Config",
@@ -172,26 +164,18 @@ class LoginForm(tk.Tk):
         # Bind the configure event to update the scrollregion
         self.extra_frame.bind(
             "<Configure>",
-            lambda event: self.extra_canvas.configure(
-                scrollregion=self.extra_canvas.bbox("all")
-            ),
+            lambda event: self.extra_canvas.configure(scrollregion=self.extra_canvas.bbox("all")),
         )
 
         # Bind a configure event to the container to adjust the width
-        self.extra_frame_container.bind(
-            "<Configure>", self._on_extra_container_configure
-        )
+        self.extra_frame_container.bind("<Configure>", self._on_extra_container_configure)
 
         # Hash Rounds
         hash_rounds_label = ttk.Label(self.extra_frame, text="Hash Rounds:")
         hash_rounds_label.grid(row=0, column=0, padx=(0, 10), pady=5, sticky=tk.W)
-        self.hash_rounds_entry = ttk.Entry(
-            self.extra_frame, width=50, font=("Helvetica", 13)
-        )
+        self.hash_rounds_entry = ttk.Entry(self.extra_frame, width=50, font=("Helvetica", 13))
         self.hash_rounds_entry.insert(0, str(self.config.data["hash_rounds"]))
-        self.hash_rounds_entry.grid(
-            row=0, column=1, padx=10, pady=5, sticky=tk.W + tk.E
-        )
+        self.hash_rounds_entry.grid(row=0, column=1, padx=10, pady=5, sticky=tk.W + tk.E)
 
         # Salt
         salt_label = ttk.Label(self.extra_frame, text="Salt:")
@@ -217,26 +201,18 @@ class LoginForm(tk.Tk):
         local_clipboard_size_label = ttk.Label(
             self.extra_frame, text="Maximum Clipboard Size\nLocal Limit (in bytes):"
         )
-        local_clipboard_size_label.grid(
-            row=3, column=0, padx=(0, 10), pady=5, sticky=tk.W
-        )
+        local_clipboard_size_label.grid(row=3, column=0, padx=(0, 10), pady=5, sticky=tk.W)
         self.local_clipboard_size_entry = ttk.Entry(
             self.extra_frame, width=50, font=("Helvetica", 13)
         )
         self.local_clipboard_size_entry.insert(
             0, str(self.config.data["max_clipboard_size_local_limit_bytes"] or "")
         )
-        self.local_clipboard_size_entry.grid(
-            row=3, column=1, padx=10, pady=5, sticky=tk.W + tk.E
-        )
+        self.local_clipboard_size_entry.grid(row=3, column=1, padx=10, pady=5, sticky=tk.W + tk.E)
 
         # Enable Image Sharing Checkbox
-        enable_image_sharing_label = ttk.Label(
-            self.extra_frame, text="Enable Image Sharing:"
-        )
-        enable_image_sharing_label.grid(
-            row=4, column=0, padx=(0, 10), pady=5, sticky=tk.W
-        )
+        enable_image_sharing_label = ttk.Label(self.extra_frame, text="Enable Image Sharing:")
+        enable_image_sharing_label.grid(row=4, column=0, padx=(0, 10), pady=5, sticky=tk.W)
         self.enable_image_sharing_var = tk.BooleanVar(
             value=self.config.data["enable_image_sharing"]
         )
@@ -244,27 +220,17 @@ class LoginForm(tk.Tk):
             self.extra_frame,
             variable=self.enable_image_sharing_var,
         )
-        self.enable_image_sharing_checkbox.grid(
-            row=4, column=1, padx=10, pady=5, sticky=tk.W
-        )
+        self.enable_image_sharing_checkbox.grid(row=4, column=1, padx=10, pady=5, sticky=tk.W)
 
         # Enable File Sharing Checkbox
-        enable_file_sharing_label = ttk.Label(
-            self.extra_frame, text="Enable File Sharing:"
-        )
-        enable_file_sharing_label.grid(
-            row=5, column=0, padx=(0, 10), pady=5, sticky=tk.W
-        )
-        self.enable_file_sharing_var = tk.BooleanVar(
-            value=self.config.data["enable_file_sharing"]
-        )
+        enable_file_sharing_label = ttk.Label(self.extra_frame, text="Enable File Sharing:")
+        enable_file_sharing_label.grid(row=5, column=0, padx=(0, 10), pady=5, sticky=tk.W)
+        self.enable_file_sharing_var = tk.BooleanVar(value=self.config.data["enable_file_sharing"])
         self.enable_file_sharing_checkbox = ttk.Checkbutton(
             self.extra_frame,
             variable=self.enable_file_sharing_var,
         )
-        self.enable_file_sharing_checkbox.grid(
-            row=5, column=1, padx=10, pady=5, sticky=tk.W
-        )
+        self.enable_file_sharing_checkbox.grid(row=5, column=1, padx=10, pady=5, sticky=tk.W)
 
         # Default File Download Location
         default_file_download_location_label = ttk.Label(
@@ -304,10 +270,9 @@ class LoginForm(tk.Tk):
         self.deiconify()  # Show window
         self.update_idletasks()
         center_window(self, self.max_window_height)
-        
+
         # Drop always-on-top after showing
         self.after(300, lambda: self.attributes("-topmost", False))
-        
 
     def _toggle_password(self, event=None):
         if self.password_entry.cget("show") == "*":
@@ -408,15 +373,11 @@ class LoginForm(tk.Tk):
         self.config.data["save_password"] = self.save_password_var.get()
 
         # Validate max_clipboard_size_local_limit_bytes
-        max_clipboard_size_local_limit_bytes_input = (
-            self.local_clipboard_size_entry.get().strip()
-        )
+        max_clipboard_size_local_limit_bytes_input = self.local_clipboard_size_entry.get().strip()
         if max_clipboard_size_local_limit_bytes_input == "":
             self.config.data["max_clipboard_size_local_limit_bytes"] = None
         else:
-            if not LoginForm.is_positive_integer(
-                max_clipboard_size_local_limit_bytes_input
-            ):
+            if not LoginForm.is_positive_integer(max_clipboard_size_local_limit_bytes_input):
                 CustomDialog(
                     "Invalid Input\nMax Clipboard Size Local Limit must be a positive integer.",
                     msg_type="error",
@@ -430,9 +391,7 @@ class LoginForm(tk.Tk):
         self.config.data["enable_file_sharing"] = self.enable_file_sharing_var.get()
 
         # Validate file download location
-        default_file_download_location = (
-            self.default_file_download_location_entry.get().strip()
-        )
+        default_file_download_location = self.default_file_download_location_entry.get().strip()
         if default_file_download_location == "":
             self.config.data["default_file_download_location"] = ""
         else:
@@ -442,9 +401,7 @@ class LoginForm(tk.Tk):
                     msg_type="error",
                 ).mainloop()
                 return  # retry login
-            self.config.data["default_file_download_location"] = (
-                default_file_download_location
-            )
+            self.config.data["default_file_download_location"] = default_file_download_location
 
         # call login callback
         if self.on_login_callback:

--- a/ClipCascade_Desktop/src/gui/login.py
+++ b/ClipCascade_Desktop/src/gui/login.py
@@ -48,7 +48,12 @@ class LoginForm(tk.Tk):
         main_frame.pack(fill=tk.BOTH, expand=True)
 
         # Title Label
-        title_label = ttk.Label(main_frame, text="Please Log In", font=("Helvetica", 16, "bold"))
+        title_label = ttk.Label(
+            main_frame,
+            text="Please Log In",
+            font=("Helvetica", 16, "bold"),
+            takefocus=False,
+        )
         title_label.pack(pady=(0, 10))
 
         # Create a frame for the fields
@@ -73,7 +78,9 @@ class LoginForm(tk.Tk):
         self.password_entry.insert(0, self.config.data["password"])
         self.password_entry.pack(side=tk.LEFT, fill=tk.X, expand=True)
 
-        self.eye_icon = ttk.Label(self.password_frame, text="🙈", cursor="hand2")
+        self.eye_icon = ttk.Label(
+            self.password_frame, text="🙈", cursor="hand2", takefocus=False
+        )
         self.eye_icon.pack(side=tk.RIGHT, padx=(5, 0))
         self.eye_icon.bind("<Button-1>", self._toggle_password)
 
@@ -97,13 +104,17 @@ class LoginForm(tk.Tk):
             checks_frame,
             text="Enable Encryption (recommended)",
             variable=self.cipher_var,
+            takefocus=False,
         )
         self.cipher_checkbox.pack(pady=3, anchor=tk.W)
 
         # Notification Checkbox
         self.notification_var = tk.BooleanVar(value=self.config.data["notification"])
         self.notification_checkbox = ttk.Checkbutton(
-            checks_frame, text="Enable Notification", variable=self.notification_var
+            checks_frame,
+            text="Enable Notification",
+            variable=self.notification_var,
+            takefocus=False,
         )
         self.notification_checkbox.pack(pady=3, anchor=tk.W)
 
@@ -125,6 +136,7 @@ class LoginForm(tk.Tk):
             fg=self.toggle_normal_color,
             cursor="hand2",
             font=font.Font(family="Helvetica", size=13, underline=True),
+            takefocus=False,
         )
         self.toggle_label.pack(pady=(5, 10))
         self.toggle_label.bind("<Button-1>", self._toggle_extra_config)
@@ -140,7 +152,10 @@ class LoginForm(tk.Tk):
 
         # Create a canvas inside the extra_frame_container
         self.extra_canvas = tk.Canvas(
-            self.extra_frame_container, borderwidth=0, background="#f0f0f0"
+            self.extra_frame_container,
+            borderwidth=0,
+            background="#f0f0f0",
+            takefocus=False,
         )
         self.extra_canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
 
@@ -149,6 +164,7 @@ class LoginForm(tk.Tk):
             self.extra_frame_container,
             orient="vertical",
             command=self.extra_canvas.yview,
+            takefocus=False,
         )
         self.scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
 
@@ -194,6 +210,7 @@ class LoginForm(tk.Tk):
         self.save_password_checkbox = ttk.Checkbutton(
             self.extra_frame,
             variable=self.save_password_var,
+            takefocus=False,
         )
         self.save_password_checkbox.grid(row=2, column=1, padx=10, pady=5, sticky=tk.W)
 
@@ -219,6 +236,7 @@ class LoginForm(tk.Tk):
         self.enable_image_sharing_checkbox = ttk.Checkbutton(
             self.extra_frame,
             variable=self.enable_image_sharing_var,
+            takefocus=False,
         )
         self.enable_image_sharing_checkbox.grid(row=4, column=1, padx=10, pady=5, sticky=tk.W)
 
@@ -229,6 +247,7 @@ class LoginForm(tk.Tk):
         self.enable_file_sharing_checkbox = ttk.Checkbutton(
             self.extra_frame,
             variable=self.enable_file_sharing_var,
+            takefocus=False,
         )
         self.enable_file_sharing_checkbox.grid(row=5, column=1, padx=10, pady=5, sticky=tk.W)
 
@@ -267,6 +286,8 @@ class LoginForm(tk.Tk):
         # on press enter key
         self.bind("<Return>", lambda event: self.on_login())
 
+        self._sync_login_tab_order()
+
         self.deiconify()  # Show window
         self.update_idletasks()
         center_window(self, self.max_window_height)
@@ -276,6 +297,18 @@ class LoginForm(tk.Tk):
 
         if PLATFORM == MACOS:
             self.after(400, self._macos_restore_focus)
+
+    def _sync_login_tab_order(self):
+        """Tab cycles username → password → server → Login → [extra entries if shown] → repeat.
+        Checkboxes and chrome are excluded from keyboard focus."""
+        extra_entries = (
+            self.hash_rounds_entry,
+            self.salt_entry,
+            self.local_clipboard_size_entry,
+            self.default_file_download_location_entry,
+        )
+        for w in extra_entries:
+            w.configure(takefocus=bool(self.show_extra))
 
     def _macos_restore_focus(self):
         """Force macOS to properly activate and focus the window.
@@ -300,13 +333,23 @@ class LoginForm(tk.Tk):
 
     def _toggle_extra_config(self, event=None):
         """Toggle the visibility of the extra configuration fields."""
+        extra_entries = (
+            self.hash_rounds_entry,
+            self.salt_entry,
+            self.local_clipboard_size_entry,
+            self.default_file_download_location_entry,
+        )
         if self.show_extra:
+            focused = self.focus_get()
+            if focused in extra_entries:
+                self.login_button.focus_set()
             self.extra_frame_container.pack_forget()
             self.toggle_label.config(text="Enable Extra Config")
         else:
             self.extra_frame_container.pack(fill=tk.BOTH, expand=True)
             self.toggle_label.config(text="Hide Extra Config")
         self.show_extra = not self.show_extra
+        self._sync_login_tab_order()
 
         self.update_idletasks()
         self.geometry("")

--- a/ClipCascade_Desktop/src/gui/message_box.py
+++ b/ClipCascade_Desktop/src/gui/message_box.py
@@ -1,6 +1,14 @@
 from tkinter import messagebox
-
+import tkinter as tk
+from utils.window_manager import center_window
 
 class MessageBox:
     def askquestion(self, title, message):
-        return messagebox.askquestion(title, message)
+        parent = tk.Tk()
+        parent.update_idletasks()
+        parent.geometry("1x1+0+0")
+        center_window(parent)
+        parent.attributes("-topmost", True)
+        result = messagebox.askquestion(title, message, parent=parent)
+        parent.destroy()
+        return result

--- a/ClipCascade_Desktop/src/gui/message_box.py
+++ b/ClipCascade_Desktop/src/gui/message_box.py
@@ -1,14 +1,6 @@
 from tkinter import messagebox
-import tkinter as tk
-from utils.window_manager import center_window
+
 
 class MessageBox:
     def askquestion(self, title, message):
-        parent = tk.Tk()
-        parent.update_idletasks()
-        parent.geometry("1x1+0+0")
-        center_window(parent)
-        parent.attributes("-topmost", True)
-        result = messagebox.askquestion(title, message, parent=parent)
-        parent.destroy()
-        return result
+        return messagebox.askquestion(title, message)

--- a/ClipCascade_Desktop/src/gui/tray.py
+++ b/ClipCascade_Desktop/src/gui/tray.py
@@ -70,8 +70,9 @@ class TaskbarPanel:
     def run(self):
         self.icon.run()
 
-    def create_clipboard_icon(self):
-        width, height = 64, 64  # Icon dimensions
+    def _create_clipboard_base_image(self):
+        """Shared clipboard artwork for normal tray icon and file-download badge variant."""
+        width, height = 64, 64
         image = Image.new("RGBA", (width, height), (0, 0, 0, 0))
         draw = ImageDraw.Draw(image)
 
@@ -80,36 +81,31 @@ class TaskbarPanel:
 
         board_coords = (12, 12, 52, 57)
         try:
-            draw.rounded_rectangle(board_coords, radius=5, fill=None, outline=outline_color, width=3)
+            draw.rounded_rectangle(
+                board_coords, radius=5, fill=None, outline=outline_color, width=3
+            )
         except (AttributeError, TypeError):
             draw.rectangle(board_coords, fill=None, outline=outline_color)
 
         clip_coords = (22, 7, 42, 17)
         try:
-            draw.rounded_rectangle(clip_coords, radius=3, fill=fill_color, outline=outline_color, width=3)
+            draw.rounded_rectangle(
+                clip_coords, radius=3, fill=fill_color, outline=outline_color, width=3
+            )
         except (AttributeError, TypeError):
             draw.rectangle(clip_coords, fill=fill_color, outline=outline_color)
 
         return image
 
+    def create_clipboard_icon(self):
+        return self._create_clipboard_base_image()
+
     def create_clipboard_icon_with_dot(self):
-        width, height = 64, 64  # Icon dimensions
-        image = Image.new("RGBA", (width, height), (255, 255, 255, 0))
-
+        """Same clipboard as normal state, plus a blue notification dot for pending file download."""
+        image = self._create_clipboard_base_image().copy()
         draw = ImageDraw.Draw(image)
+        width, height = 64, 64
 
-        # Draw a clipboard shape
-        clipboard_rect = [15, 10, 49, 50]
-        draw.rectangle(clipboard_rect, fill=(200, 200, 200), outline=(0, 0, 0))
-
-        # Draw the clipboard clip centered horizontally
-        clip_width = 10
-        clip_height = 5
-        clip_x = (clipboard_rect[0] + clipboard_rect[2]) / 2 - clip_width / 2
-        clip_rect = [clip_x, 5, clip_x + clip_width, 5 + clip_height]
-        draw.rectangle(clip_rect, fill=(150, 150, 150), outline=(0, 0, 0))
-
-        # Draw a notification dot in the top-right corner with a shiny effect
         dot_radius = 8
         dot_center_x = width - dot_radius - 5
         dot_center_y = dot_radius + 5
@@ -119,9 +115,8 @@ class TaskbarPanel:
             dot_center_x + dot_radius,
             dot_center_y + dot_radius,
         ]
-        draw.ellipse(dot_bbox, fill=(0, 128, 255, 255))  # Blue dot
+        draw.ellipse(dot_bbox, fill=(0, 128, 255, 255))
 
-        # Add a shiny highlight to the dot
         highlight_radius = dot_radius // 2
         highlight_center_x = dot_center_x - highlight_radius // 2
         highlight_center_y = dot_center_y - highlight_radius // 2
@@ -131,9 +126,7 @@ class TaskbarPanel:
             highlight_center_x + highlight_radius,
             highlight_center_y + highlight_radius,
         ]
-        draw.ellipse(
-            highlight_bbox, fill=(255, 255, 255, 180)
-        )  # Semi-transparent white highlight
+        draw.ellipse(highlight_bbox, fill=(255, 255, 255, 180))
 
         return image
 

--- a/ClipCascade_Desktop/src/gui/tray.py
+++ b/ClipCascade_Desktop/src/gui/tray.py
@@ -47,6 +47,14 @@ class TaskbarPanel:
         self.root = tk.Tk()
         self.root.withdraw()  # Hide the root window
 
+        # Hide dock icon on macOS after creating tkinter window
+        if PLATFORM == MACOS:
+            try:
+                from AppKit import NSApplication, NSApplicationActivationPolicyAccessory
+                NSApplication.sharedApplication().setActivationPolicy_(NSApplicationActivationPolicyAccessory)
+            except ImportError:
+                pass
+
         # Initial state: Connected
         self.is_connected = True
 

--- a/ClipCascade_Desktop/src/gui/tray.py
+++ b/ClipCascade_Desktop/src/gui/tray.py
@@ -64,20 +64,23 @@ class TaskbarPanel:
 
     def create_clipboard_icon(self):
         width, height = 64, 64  # Icon dimensions
-        image = Image.new("RGBA", (width, height), (255, 255, 255, 0))
-
+        image = Image.new("RGBA", (width, height), (0, 0, 0, 0))
         draw = ImageDraw.Draw(image)
 
-        # Draw a clipboard shape
-        clipboard_rect = [15, 10, 49, 50]
-        draw.rectangle(clipboard_rect, fill=(200, 200, 200), outline=(0, 0, 0))
+        fill_color = (220, 220, 220)
+        outline_color = (255, 255, 255)
 
-        # Draw the clipboard clip centered horizontally
-        clip_width = 10
-        clip_height = 5
-        clip_x = (clipboard_rect[0] + clipboard_rect[2]) / 2 - clip_width / 2
-        clip_rect = [clip_x, 5, clip_x + clip_width, 5 + clip_height]
-        draw.rectangle(clip_rect, fill=(150, 150, 150), outline=(0, 0, 0))
+        board_coords = (12, 12, 52, 57)
+        try:
+            draw.rounded_rectangle(board_coords, radius=5, fill=None, outline=outline_color, width=3)
+        except (AttributeError, TypeError):
+            draw.rectangle(board_coords, fill=None, outline=outline_color)
+
+        clip_coords = (22, 7, 42, 17)
+        try:
+            draw.rounded_rectangle(clip_coords, radius=3, fill=fill_color, outline=outline_color, width=3)
+        except (AttributeError, TypeError):
+            draw.rectangle(clip_coords, fill=fill_color, outline=outline_color)
 
         return image
 

--- a/ClipCascade_Desktop/src/main.py
+++ b/ClipCascade_Desktop/src/main.py
@@ -16,6 +16,8 @@ class Main:
     def __init__(self):
         Application().run()
 
+def main():
+    Main()
 
 if __name__ == "__main__":
-    Main()
+    main()

--- a/ClipCascade_Desktop/src/p2p/p2p_manager.py
+++ b/ClipCascade_Desktop/src/p2p/p2p_manager.py
@@ -6,7 +6,7 @@ import asyncio
 import uuid
 
 from threading import Lock, Thread
-from typing import List, Optional
+from typing import Dict, List, Optional
 from core.config import Config
 from interfaces.ws_interface import WSInterface
 from utils.cipher_manager import CipherManager
@@ -62,6 +62,12 @@ class P2PManager(WSInterface):
         # If PEER_LIST arrives before ASSIGNED_ID (e.g. right after signaling reconnect), mesh setup waits.
         self._pending_peer_list: Optional[List[str]] = None
 
+        # True during full P2P teardown (logout / signaling reconnect prep); suppresses ICE recovery.
+        self._p2p_shutting_down: bool = False
+        # Serialize recover + offer handling per peer (same asyncio loop as signaling handlers).
+        self._peer_recovery_locks: Dict[str, asyncio.Lock] = {}
+        self._dc_heartbeat_handle: Optional[asyncio.TimerHandle] = None
+
         # Event loop for asyncio
         self.loop = asyncio.new_event_loop()
         self.loop_thread = Thread(
@@ -72,6 +78,37 @@ class P2PManager(WSInterface):
     def schedule_task(self, coro):
         """Submit an async function to the manager's event loop thread."""
         return asyncio.run_coroutine_threadsafe(coro, self.loop)
+
+    def _cancel_dc_heartbeat(self) -> None:
+        if self._dc_heartbeat_handle is not None:
+            self._dc_heartbeat_handle.cancel()
+            self._dc_heartbeat_handle = None
+
+    def _dc_heartbeat_tick(self) -> None:
+        self._dc_heartbeat_handle = None
+        if self.disconnected or self._p2p_shutting_down or not self.is_connected:
+            return
+        ping = json.dumps({"_cc_keepalive": True})
+        for ch in list(self.data_channels.values()):
+            try:
+                if getattr(ch, "readyState", "") == "open":
+                    ch.send(ping)
+            except Exception:
+                pass
+        self._schedule_next_dc_heartbeat()
+
+    def _schedule_next_dc_heartbeat(self) -> None:
+        if self.disconnected or self._p2p_shutting_down or not self.is_connected:
+            return
+        self._cancel_dc_heartbeat()
+        self._dc_heartbeat_handle = self.loop.call_later(
+            P2P_DC_HEARTBEAT_INTERVAL_SEC, self._dc_heartbeat_tick
+        )
+
+    def _restart_dc_heartbeat(self) -> None:
+        self._cancel_dc_heartbeat()
+        if not self.disconnected and not self._p2p_shutting_down and self.is_connected:
+            self._schedule_next_dc_heartbeat()
 
     def set_tray_ref(self, sys_tray: TaskbarPanel):
         """
@@ -240,6 +277,7 @@ class P2PManager(WSInterface):
 
             self.is_connected = True
             self.is_auto_reconnecting = False
+            self.loop.call_soon_threadsafe(self._restart_dc_heartbeat)
             if not self.first_conn_lost:
                 self.first_conn_lost = True
                 self.notification_manager.notify(
@@ -300,26 +338,32 @@ class P2PManager(WSInterface):
             logging.error(f"Failed to disconnect websocket: {e}")
 
     async def _cleanup_peer_connections(self):
+        self._p2p_shutting_down = True
+        self._cancel_dc_heartbeat()
         try:
-            for dc in list(self.data_channels.values()):
-                try:
-                    dc.close()
-                except Exception:
-                    pass
+            try:
+                for dc in list(self.data_channels.values()):
+                    try:
+                        dc.close()
+                    except Exception:
+                        pass
 
-            for pc in list(self.peer_connections.values()):
-                try:
-                    await asyncio.wait_for(pc.close(), timeout=P2P_PC_CLOSE_TIMEOUT_SEC)
-                except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
-                    pass
+                for pc in list(self.peer_connections.values()):
+                    try:
+                        await asyncio.wait_for(pc.close(), timeout=P2P_PC_CLOSE_TIMEOUT_SEC)
+                    except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+                        pass
+            finally:
+                self.my_peer_id = None
+                self.peers.clear()
+                self.peer_connections.clear()
+                self.data_channels.clear()
+                self._pending_peer_list = None
+                self._peer_recovery_locks.clear()
+                with self._live_connections_lock:
+                    self.live_connections = 0
         finally:
-            self.my_peer_id = None
-            self.peers.clear()
-            self.peer_connections.clear()
-            self.data_channels.clear()
-            self._pending_peer_list = None
-            with self._live_connections_lock:
-                self.live_connections = 0
+            self._p2p_shutting_down = False
 
     async def _handle_peer_list(self, peer_list):
         """
@@ -327,11 +371,10 @@ class P2PManager(WSInterface):
         We create connections or data channels accordingly.
         """
         updated_peers = set(peer_list)
-        # 1) Remove any stale peers
-        await self._remove_stale_peers(updated_peers)
-
-        # 2) Update self.peers
+        # Keep room membership in sync before closing stale PCs so ICE recovery does not
+        # treat removed peers as still present when data-channel close handlers run.
         self.peers = updated_peers
+        await self._remove_stale_peers(updated_peers)
 
         if self.my_peer_id is None:
             self._pending_peer_list = list(peer_list)
@@ -364,6 +407,7 @@ class P2PManager(WSInterface):
         stale_ids = set(self.peer_connections.keys()) - updated_peers
         for old_pid in stale_ids:
             logging.debug(f"Removing stale peer: {old_pid}")
+            self._peer_recovery_locks.pop(old_pid, None)
             # Close data channel
             dc = self.data_channels.pop(old_pid, None)
             if dc is not None:
@@ -381,6 +425,76 @@ class P2PManager(WSInterface):
                     pass
 
         self._sync_live_connections_count()
+
+    def _get_peer_lock(self, peer_id: str) -> asyncio.Lock:
+        lock = self._peer_recovery_locks.get(peer_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._peer_recovery_locks[peer_id] = lock
+        return lock
+
+    async def _dispose_peer_connection(self, peer_id: str) -> None:
+        """Close and drop one peer's DC/PC without changing self.peers (used by recovery and offer handling)."""
+        dc = self.data_channels.pop(peer_id, None)
+        if dc is not None:
+            try:
+                dc.close()
+            except Exception:
+                pass
+        pc = self.peer_connections.pop(peer_id, None)
+        if pc is not None:
+            try:
+                await asyncio.wait_for(pc.close(), timeout=P2P_PC_CLOSE_TIMEOUT_SEC)
+            except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+                pass
+        self._sync_live_connections_count()
+
+    async def _recover_peer_transport(
+        self, remote_peer_id: str, dead_pc: Optional[RTCPeerConnection] = None
+    ) -> None:
+        """
+        Re-establish WebRTC to a peer that is still in the room after ICE failure or data-channel loss.
+        Signaling WebSocket stays up; no server change required.
+        """
+        if self._p2p_shutting_down or self.disconnected or self.is_login_phase:
+            return
+        if self.my_peer_id is None or remote_peer_id not in self.peers:
+            return
+        if dead_pc is not None and self.peer_connections.get(remote_peer_id) is not dead_pc:
+            return
+
+        lock = self._get_peer_lock(remote_peer_id)
+        async with lock:
+            if self._p2p_shutting_down or self.disconnected or self.my_peer_id is None:
+                return
+            if remote_peer_id not in self.peers:
+                return
+            if dead_pc is not None and self.peer_connections.get(remote_peer_id) is not dead_pc:
+                return
+            if dead_pc is None:
+                ch = self.data_channels.get(remote_peer_id)
+                if ch is not None and getattr(ch, "readyState", "") == "open":
+                    return
+
+            logging.info("P2P: recovering WebRTC transport to peer %s", remote_peer_id)
+
+            await self._dispose_peer_connection(remote_peer_id)
+
+            if (
+                self._p2p_shutting_down
+                or self.my_peer_id is None
+                or remote_peer_id not in self.peers
+            ):
+                return
+
+            pc = self._create_peer_connection(remote_peer_id)
+            self.peer_connections[remote_peer_id] = pc
+
+            if self.my_peer_id < remote_peer_id:
+                channel = pc.createDataChannel("cliptext")
+                self.data_channels[remote_peer_id] = channel
+                self._setup_data_channel(remote_peer_id, channel)
+                await self._create_offer(remote_peer_id)
 
     def _create_peer_connection(self, remote_peer_id: str) -> RTCPeerConnection:
         """
@@ -423,6 +537,15 @@ class P2PManager(WSInterface):
                     }
                 )
 
+        @pc.on("connectionstatechange")
+        def on_connectionstatechange():
+            try:
+                state = pc.connectionState
+            except Exception:
+                return
+            if state in ("failed", "closed"):
+                self.schedule_task(self._recover_peer_transport(remote_peer_id, pc))
+
         @pc.on("datachannel")
         def on_datachannel(channel):
             # This fires when the remote side creates a datachannel
@@ -454,29 +577,45 @@ class P2PManager(WSInterface):
     async def _handle_offer(self, from_peer_id: str, offer: dict):
         """
         Respond to an incoming OFFER from a remote peer.
+        Always replaces any existing RTCPeerConnection for this peer before applying
+        the SDP: recovery sends a full new offer; applying it on an already-connected
+        PC leaves ICE/datachannel mismatched (remote shows Peers: 1, local 0).
         """
-        pc = self.peer_connections.get(from_peer_id)
-        if not pc:
+        if self._p2p_shutting_down:
+            return
+        # Ignore delayed/stale OFFERs for peers no longer present in the latest PEER_LIST.
+        # Startup guard: allow early signaling before ASSIGNED_ID/PEER_LIST is established.
+        if self.my_peer_id is not None and self.peers and from_peer_id not in self.peers:
+            logging.debug("Ignoring stale OFFER for removed peer: %s", from_peer_id)
+            return
+        lock = self._get_peer_lock(from_peer_id)
+        async with lock:
+            # TOCTOU guard: PEER_LIST can change after the outer fast-path check.
+            if self.my_peer_id is not None and self.peers and from_peer_id not in self.peers:
+                logging.debug("Ignoring stale OFFER for removed peer (in-lock): %s", from_peer_id)
+                return
+            if from_peer_id in self.peer_connections:
+                await self._dispose_peer_connection(from_peer_id)
             pc = self._create_peer_connection(from_peer_id)
             self.peer_connections[from_peer_id] = pc
 
-        desc = RTCSessionDescription(sdp=offer["sdp"], type=offer["type"])
-        await pc.setRemoteDescription(desc)
+            desc = RTCSessionDescription(sdp=offer["sdp"], type=offer["type"])
+            await pc.setRemoteDescription(desc)
 
-        answer = await pc.createAnswer()
-        await pc.setLocalDescription(answer)
+            answer = await pc.createAnswer()
+            await pc.setLocalDescription(answer)
 
-        self.ws_send(
-            {
-                "type": "ANSWER",
-                "fromPeerId": self.my_peer_id,
-                "toPeerId": from_peer_id,
-                "answer": {
-                    "type": pc.localDescription.type,
-                    "sdp": pc.localDescription.sdp,
-                },
-            }
-        )
+            self.ws_send(
+                {
+                    "type": "ANSWER",
+                    "fromPeerId": self.my_peer_id,
+                    "toPeerId": from_peer_id,
+                    "answer": {
+                        "type": pc.localDescription.type,
+                        "sdp": pc.localDescription.sdp,
+                    },
+                }
+            )
 
     async def _handle_answer(self, from_peer_id: str, answer: dict):
         """
@@ -485,6 +624,9 @@ class P2PManager(WSInterface):
         pc = self.peer_connections.get(from_peer_id)
         if not pc:
             logging.warning(f"No peer connection exists for id={from_peer_id}, ignoring ANSWER.")
+            return
+        if getattr(pc, "connectionState", "") in ("failed", "closed"):
+            logging.debug("Ignoring ANSWER for dead peer connection: %s", from_peer_id)
             return
         desc = RTCSessionDescription(sdp=answer["sdp"], type=answer["type"])
         await pc.setRemoteDescription(desc)
@@ -498,6 +640,9 @@ class P2PManager(WSInterface):
             logging.warning(
                 f"No peer connection exists for id={from_peer_id}, ignoring ICE_CANDIDATE."
             )
+            return
+        if getattr(pc, "connectionState", "") in ("failed", "closed"):
+            logging.debug("Ignoring ICE candidate for dead peer connection: %s", from_peer_id)
             return
 
         parsed_candidate = P2PManager.parse_ice_candidate_line(candidate_data.get("candidate"))
@@ -536,6 +681,7 @@ class P2PManager(WSInterface):
         @channel.on("close")
         def on_close():
             self._sync_live_connections_count()
+            self.schedule_task(self._recover_peer_transport(remote_peer_id, None))
 
         @channel.on("error")
         def on_error(e):
@@ -606,8 +752,10 @@ class P2PManager(WSInterface):
 
     def _receive(self, frame: any) -> str:
         try:
-            self.reset_sending_fragment_id()
             body = json.loads(frame)
+            if isinstance(body, dict) and body.get("_cc_keepalive") is True:
+                return
+            self.reset_sending_fragment_id()
             payload = body["payload"]
             payload_type = body.get("type", "text")
             metadata = body.get("metadata")

--- a/ClipCascade_Desktop/src/p2p/p2p_manager.py
+++ b/ClipCascade_Desktop/src/p2p/p2p_manager.py
@@ -13,6 +13,7 @@ from utils.cipher_manager import CipherManager
 from clipboard.clipboard_manager import ClipboardManager
 from utils.notification_manager import NotificationManager
 from utils.request_manager import RequestManager
+from utils.ssl_helper import websocket_sslopt_for_config
 from core.constants import *
 from aiortc import (
     RTCPeerConnection,
@@ -27,11 +28,6 @@ if PLATFORM.startswith(LINUX) and LINUX_USE_CLI_UI:
     from cli.tray import TaskbarPanel
 else:
     from gui.tray import TaskbarPanel
-
-if PLATFORM == MACOS:
-    import ssl
-    import certifi
-
 
 class P2PManager(WSInterface):
     def __init__(self, config: Config, is_login_phase=True):
@@ -114,7 +110,13 @@ class P2PManager(WSInterface):
         """
         try:
             if self.ws_client is not None:
-                return
+                if self.is_connected:
+                    return True, ""
+                try:
+                    self.ws_client.close()
+                except Exception:
+                    pass
+                self.ws_client = None
 
             self.ws_client = websocket.WebSocketApp(
                 url=self.config.data["websocket_url"],
@@ -129,9 +131,9 @@ class P2PManager(WSInterface):
                 "ping_interval": P2P_WS_PING_INTERVAL_SEC,
                 "ping_timeout": P2P_WS_PING_TIMEOUT_SEC,
             }
-            if PLATFORM == MACOS:
-                ssl_context = ssl.create_default_context(cafile=certifi.where())
-                ws_run_kw["sslopt"] = {"context": ssl_context}
+            ws_sslopt = websocket_sslopt_for_config(self.config)
+            if ws_sslopt:
+                ws_run_kw["sslopt"] = ws_sslopt
             Thread(
                 target=self.ws_client.run_forever,
                 kwargs=ws_run_kw,
@@ -160,6 +162,10 @@ class P2PManager(WSInterface):
         except Exception as e:
             msg = f"Failed to connect websocket: {e}"
             logging.error(msg)
+            try:
+                self.ws_close()
+            except Exception:
+                pass
             return False, msg
 
     def _on_ws_close(self, ws, *args):

--- a/ClipCascade_Desktop/src/p2p/p2p_manager.py
+++ b/ClipCascade_Desktop/src/p2p/p2p_manager.py
@@ -23,7 +23,7 @@ from aiortc import (
     RTCDataChannel,
 )
 
-if PLATFORM.startswith(LINUX) and not XMODE:
+if PLATFORM.startswith(LINUX) and LINUX_USE_CLI_UI:
     from cli.tray import TaskbarPanel
 else:
     from gui.tray import TaskbarPanel

--- a/ClipCascade_Desktop/src/p2p/p2p_manager.py
+++ b/ClipCascade_Desktop/src/p2p/p2p_manager.py
@@ -42,6 +42,7 @@ class P2PManager(WSInterface):
         self.is_connected = False
         self.disconnected = False
         self.is_auto_reconnecting = False
+        self._suppress_auto_reconnect_once = False
         self.is_clipboard_monitoring_on = False
 
         # Fragment variables
@@ -208,6 +209,9 @@ class P2PManager(WSInterface):
     def _on_ws_close(self, ws, *args):
         self.ws_client = None
         self.is_connected = False
+        if self._suppress_auto_reconnect_once:
+            self._suppress_auto_reconnect_once = False
+            return
         # Auto Reconnect
         if not self.is_login_phase and not self.disconnected:
             self.is_auto_reconnecting = True
@@ -223,6 +227,7 @@ class P2PManager(WSInterface):
     def manual_reconnect(self):
         if not self.is_auto_reconnecting:
             self.disconnected = False
+            self._suppress_auto_reconnect_once = self.ws_client is not None
             self.ws_close()
             self.is_connected = False
             self.connect()

--- a/ClipCascade_Desktop/src/p2p/p2p_manager.py
+++ b/ClipCascade_Desktop/src/p2p/p2p_manager.py
@@ -258,6 +258,16 @@ class P2PManager(WSInterface):
         except Exception as e:
             logging.error(f"Failed to handle websocket message: {e}")
 
+    async def _prepare_reconnect_bootstrap(self):
+        """
+        Runs on the asyncio signaling loop thread.
+        Resets bootstrap state and tears down old mesh without clobbering newer
+        ASSIGNED_ID / PEER_LIST values that may arrive during cleanup.
+        """
+        self.my_peer_id = None
+        self._pending_peer_list = None
+        await self._cleanup_peer_connections(clear_bootstrap_state=False)
+
     def _on_ws_open(self, ws, *args):
         try:
             if self.disconnected:
@@ -266,7 +276,9 @@ class P2PManager(WSInterface):
 
             # Tear down WebRTC after any signaling reconnect so PEER_LIST recreates PCs.
             try:
-                fut = asyncio.run_coroutine_threadsafe(self._cleanup_peer_connections(), self.loop)
+                fut = asyncio.run_coroutine_threadsafe(
+                    self._prepare_reconnect_bootstrap(), self.loop
+                )
                 # Upper bound: N peers * P2P_PC_CLOSE_TIMEOUT + margin;
                 fut.result(timeout=90)
             except Exception as e:
@@ -337,7 +349,7 @@ class P2PManager(WSInterface):
         except Exception as e:
             logging.error(f"Failed to disconnect websocket: {e}")
 
-    async def _cleanup_peer_connections(self):
+    async def _cleanup_peer_connections(self, clear_bootstrap_state: bool = True):
         self._p2p_shutting_down = True
         self._cancel_dc_heartbeat()
         try:
@@ -354,11 +366,13 @@ class P2PManager(WSInterface):
                     except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
                         pass
             finally:
-                self.my_peer_id = None
+                if clear_bootstrap_state:
+                    self.my_peer_id = None
                 self.peers.clear()
                 self.peer_connections.clear()
                 self.data_channels.clear()
-                self._pending_peer_list = None
+                if clear_bootstrap_state:
+                    self._pending_peer_list = None
                 self._peer_recovery_locks.clear()
                 with self._live_connections_lock:
                     self.live_connections = 0

--- a/ClipCascade_Desktop/src/p2p/p2p_manager.py
+++ b/ClipCascade_Desktop/src/p2p/p2p_manager.py
@@ -65,7 +65,7 @@ class P2PManager(WSInterface):
         self.data_channels: dict[str, RTCDataChannel] = (
             {}
         )  # Mapping: peer_id -> DataChannel
-        self.live_connections: int = 0  # Number of active connections
+        self._live_peer_ids: set[str] = set()  # Peer IDs with open data channels
 
         # Event loop for asyncio
         self.loop = asyncio.new_event_loop()
@@ -73,6 +73,10 @@ class P2PManager(WSInterface):
             target=self.loop.run_forever, name="P2PManagerEventLoopThread", daemon=True
         )
         self.loop_thread.start()
+
+    @property
+    def live_connections(self) -> int:
+        return len(self._live_peer_ids)
 
     def schedule_task(self, coro):
         """Submit an async function to the manager's event loop thread."""
@@ -118,18 +122,16 @@ class P2PManager(WSInterface):
                 on_close=self._on_ws_close,
             )
 
+            ws_kwargs = {"ping_interval": 30, "ping_timeout": 10}
             if PLATFORM == MACOS:
                 ssl_context = ssl.create_default_context(cafile=certifi.where())
-                Thread(
-                    target=self.ws_client.run_forever,
-                    kwargs={"sslopt": {"context": ssl_context}},
-                    daemon=True,
-                ).start()
-            else:
-                Thread(
-                    target=self.ws_client.run_forever,
-                    daemon=True,
-                ).start()
+                ws_kwargs["sslopt"] = {"context": ssl_context}
+
+            Thread(
+                target=self.ws_client.run_forever,
+                kwargs=ws_kwargs,
+                daemon=True,
+            ).start()
 
             if not self.is_clipboard_monitoring_on:
                 # Start clipboard monitoring
@@ -167,8 +169,17 @@ class P2PManager(WSInterface):
                     message="Check your internet connection. Retrying...",
                 )
                 self.first_conn_lost = False
-            time.sleep(RECONNECT_WS_TIMER)  # seconds
-            self.connect()
+            self.schedule_task(self._reconnect_after_close())
+
+    async def _reconnect_after_close(self):
+        """Clean up dead P2P connections and reconnect after a delay."""
+        try:
+            await self._cleanup_peer_connections()
+            await asyncio.sleep(RECONNECT_WS_TIMER)
+            if not self.disconnected:
+                self.connect()
+        except Exception as e:
+            logging.error(f"Failed to reconnect after close: {e}")
 
     def manual_reconnect(self):
         if not self.is_auto_reconnecting:
@@ -290,7 +301,7 @@ class P2PManager(WSInterface):
         self.peers.clear()
         self.peer_connections.clear()
         self.data_channels.clear()
-        self.live_connections = 0
+        self._live_peer_ids.clear()
 
     async def _handle_peer_list(self, peer_list):
         """
@@ -493,7 +504,7 @@ class P2PManager(WSInterface):
 
         @channel.on("open")
         def on_open():
-            self.live_connections += 1
+            self._live_peer_ids.add(remote_peer_id)
 
         # manually call on_open if the channel is already open by the time event is attached
         if channel.readyState == "open":
@@ -505,7 +516,7 @@ class P2PManager(WSInterface):
 
         @channel.on("close")
         def on_close():
-            self.live_connections -= 1
+            self._live_peer_ids.discard(remote_peer_id)
 
         @channel.on("error")
         def on_error(e):

--- a/ClipCascade_Desktop/src/p2p/p2p_manager.py
+++ b/ClipCascade_Desktop/src/p2p/p2p_manager.py
@@ -5,7 +5,8 @@ import websocket
 import asyncio
 import uuid
 
-from threading import Thread
+from threading import Lock, Thread
+from typing import List, Optional
 from core.config import Config
 from interfaces.ws_interface import WSInterface
 from utils.cipher_manager import CipherManager
@@ -21,7 +22,6 @@ from aiortc import (
     RTCConfiguration,
     RTCDataChannel,
 )
-
 
 if PLATFORM.startswith(LINUX) and not XMODE:
     from cli.tray import TaskbarPanel
@@ -50,9 +50,7 @@ class P2PManager(WSInterface):
 
         # Fragment variables
         self.sending_fragment_id = ""  # The id of the fragment currently being sent
-        self.receiving_fragments: dict = (
-            {}
-        )  # Mapping: fragmentid:str -> fragment:list[str]
+        self.receiving_fragments: dict = {}  # Mapping: fragmentid:str -> fragment:list[str]
         self.sending_fragment_stats: str = None
         self.receiving_fragment_stats: str = None
 
@@ -62,10 +60,11 @@ class P2PManager(WSInterface):
         self.peer_connections: dict[str, RTCPeerConnection] = (
             {}
         )  # Mapping: peer_id -> RTCPeerConnection
-        self.data_channels: dict[str, RTCDataChannel] = (
-            {}
-        )  # Mapping: peer_id -> DataChannel
-        self._live_peer_ids: set[str] = set()  # Peer IDs with open data channels
+        self.data_channels: dict[str, RTCDataChannel] = {}  # Mapping: peer_id -> DataChannel
+        self.live_connections: int = 0  # Number of open data channels (derived; see _sync)
+        self._live_connections_lock = Lock()
+        # If PEER_LIST arrives before ASSIGNED_ID (e.g. right after signaling reconnect), mesh setup waits.
+        self._pending_peer_list: Optional[List[str]] = None
 
         # Event loop for asyncio
         self.loop = asyncio.new_event_loop()
@@ -73,10 +72,6 @@ class P2PManager(WSInterface):
             target=self.loop.run_forever, name="P2PManagerEventLoopThread", daemon=True
         )
         self.loop_thread.start()
-
-    @property
-    def live_connections(self) -> int:
-        return len(self._live_peer_ids)
 
     def schedule_task(self, coro):
         """Submit an async function to the manager's event loop thread."""
@@ -89,9 +84,19 @@ class P2PManager(WSInterface):
         self.sys_tray = sys_tray
         self.clipboard_manager.set_tray_ref(sys_tray)
 
+    def _sync_live_connections_count(self):
+        """Set live_connections from open data channels (avoids +/- drift and negatives)."""
+        with self._live_connections_lock:
+            self.live_connections = sum(
+                1 for ch in self.data_channels.values() if getattr(ch, "readyState", "") == "open"
+            )
+
     def get_stats(self) -> str:
+        self._sync_live_connections_count()
         stats = "📊"
-        stats += f" Peers: {self.live_connections}"
+        with self._live_connections_lock:
+            n = self.live_connections
+        stats += f" Peers: {n}"
         if self.sending_fragment_stats is not None:
             stats += f" | Sending: {self.sending_fragment_stats}"
         if self.receiving_fragment_stats is not None:
@@ -113,23 +118,23 @@ class P2PManager(WSInterface):
 
             self.ws_client = websocket.WebSocketApp(
                 url=self.config.data["websocket_url"],
-                header={
-                    "Cookie": RequestManager.format_cookie(self.config.data["cookie"])
-                },
+                header={"Cookie": RequestManager.format_cookie(self.config.data["cookie"])},
                 on_open=self._on_ws_open,
                 on_error=self._on_ws_error,
                 on_message=self._on_ws_message,
                 on_close=self._on_ws_close,
             )
 
-            ws_kwargs = {"ping_interval": 30, "ping_timeout": 10}
+            ws_run_kw = {
+                "ping_interval": P2P_WS_PING_INTERVAL_SEC,
+                "ping_timeout": P2P_WS_PING_TIMEOUT_SEC,
+            }
             if PLATFORM == MACOS:
                 ssl_context = ssl.create_default_context(cafile=certifi.where())
-                ws_kwargs["sslopt"] = {"context": ssl_context}
-
+                ws_run_kw["sslopt"] = {"context": ssl_context}
             Thread(
                 target=self.ws_client.run_forever,
-                kwargs=ws_kwargs,
+                kwargs=ws_run_kw,
                 daemon=True,
             ).start()
 
@@ -169,21 +174,14 @@ class P2PManager(WSInterface):
                     message="Check your internet connection. Retrying...",
                 )
                 self.first_conn_lost = False
-            self.schedule_task(self._reconnect_after_close())
-
-    async def _reconnect_after_close(self):
-        """Clean up dead P2P connections and reconnect after a delay."""
-        try:
-            await self._cleanup_peer_connections()
-            await asyncio.sleep(RECONNECT_WS_TIMER)
-            if not self.disconnected:
-                self.connect()
-        except Exception as e:
-            logging.error(f"Failed to reconnect after close: {e}")
+            time.sleep(RECONNECT_WS_TIMER)  # seconds
+            self.connect()
 
     def manual_reconnect(self):
         if not self.is_auto_reconnecting:
             self.disconnected = False
+            self.ws_close()
+            self.is_connected = False
             self.connect()
 
     def _on_ws_message(self, ws, message):
@@ -199,6 +197,10 @@ class P2PManager(WSInterface):
                 if self.my_peer_id is not None and self.my_peer_id != data["peerId"]:
                     await self._cleanup_peer_connections()
                 self.my_peer_id = data["peerId"]
+                if self._pending_peer_list is not None:
+                    pending = self._pending_peer_list
+                    self._pending_peer_list = None
+                    await self._handle_peer_list(pending)
             elif msg_type == "PEER_LIST":
                 await self._handle_peer_list(data["peers"])
             elif msg_type == "OFFER":
@@ -219,7 +221,17 @@ class P2PManager(WSInterface):
                 self.disconnect()
                 return
 
-            # logging.info("Websocket connected")
+            # Tear down WebRTC after any signaling reconnect so PEER_LIST recreates PCs.
+            try:
+                fut = asyncio.run_coroutine_threadsafe(self._cleanup_peer_connections(), self.loop)
+                # Upper bound: N peers * P2P_PC_CLOSE_TIMEOUT + margin;
+                fut.result(timeout=90)
+            except Exception as e:
+                logging.warning(
+                    "P2P peer cleanup on signaling open: %s",
+                    e if str(e) else type(e).__name__,
+                )
+
             self.is_connected = True
             self.is_auto_reconnecting = False
             if not self.first_conn_lost:
@@ -229,7 +241,7 @@ class P2PManager(WSInterface):
                     message="Connection re-established",
                 )
         except Exception as e:
-            logging.error(f"Failed to connect websocket: {e}")
+            logging.error(f"Failed to open P2P signaling session: {e}")
 
     def _on_ws_error(self, ws, error, *args):
         logging.debug(error)
@@ -282,26 +294,26 @@ class P2PManager(WSInterface):
             logging.error(f"Failed to disconnect websocket: {e}")
 
     async def _cleanup_peer_connections(self):
-        # Close data channels
-        for dc in self.data_channels.values():
-            try:
-                dc.close()
-            except Exception:
-                pass
+        try:
+            for dc in list(self.data_channels.values()):
+                try:
+                    dc.close()
+                except Exception:
+                    pass
 
-        # Close peer connections
-        for pc in self.peer_connections.values():
-            try:
-                await pc.close()
-            except Exception:
-                pass
-
-        # Clear all P2P-related variables
-        self.my_peer_id = None
-        self.peers.clear()
-        self.peer_connections.clear()
-        self.data_channels.clear()
-        self._live_peer_ids.clear()
+            for pc in list(self.peer_connections.values()):
+                try:
+                    await asyncio.wait_for(pc.close(), timeout=P2P_PC_CLOSE_TIMEOUT_SEC)
+                except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+                    pass
+        finally:
+            self.my_peer_id = None
+            self.peers.clear()
+            self.peer_connections.clear()
+            self.data_channels.clear()
+            self._pending_peer_list = None
+            with self._live_connections_lock:
+                self.live_connections = 0
 
     async def _handle_peer_list(self, peer_list):
         """
@@ -314,6 +326,10 @@ class P2PManager(WSInterface):
 
         # 2) Update self.peers
         self.peers = updated_peers
+
+        if self.my_peer_id is None:
+            self._pending_peer_list = list(peer_list)
+            return
 
         # 3) For each peer, if we have no RTCPeerConnection, create one
         for pid in self.peers:
@@ -354,9 +370,11 @@ class P2PManager(WSInterface):
             pc = self.peer_connections.pop(old_pid, None)
             if pc is not None:
                 try:
-                    await pc.close()
-                except Exception:
+                    await asyncio.wait_for(pc.close(), timeout=P2P_PC_CLOSE_TIMEOUT_SEC)
+                except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
                     pass
+
+        self._sync_live_connections_count()
 
     def _create_peer_connection(self, remote_peer_id: str) -> RTCPeerConnection:
         """
@@ -460,9 +478,7 @@ class P2PManager(WSInterface):
         """
         pc = self.peer_connections.get(from_peer_id)
         if not pc:
-            logging.warning(
-                f"No peer connection exists for id={from_peer_id}, ignoring ANSWER."
-            )
+            logging.warning(f"No peer connection exists for id={from_peer_id}, ignoring ANSWER.")
             return
         desc = RTCSessionDescription(sdp=answer["sdp"], type=answer["type"])
         await pc.setRemoteDescription(desc)
@@ -478,9 +494,7 @@ class P2PManager(WSInterface):
             )
             return
 
-        parsed_candidate = P2PManager.parse_ice_candidate_line(
-            candidate_data.get("candidate")
-        )
+        parsed_candidate = P2PManager.parse_ice_candidate_line(candidate_data.get("candidate"))
         ice_candidate = RTCIceCandidate(
             component=parsed_candidate.get("component"),
             foundation=parsed_candidate.get("foundation"),
@@ -504,11 +518,10 @@ class P2PManager(WSInterface):
 
         @channel.on("open")
         def on_open():
-            self._live_peer_ids.add(remote_peer_id)
+            self._sync_live_connections_count()
 
-        # manually call on_open if the channel is already open by the time event is attached
         if channel.readyState == "open":
-            on_open()
+            self._sync_live_connections_count()
 
         @channel.on("message")
         def on_message(message):
@@ -516,11 +529,12 @@ class P2PManager(WSInterface):
 
         @channel.on("close")
         def on_close():
-            self._live_peer_ids.discard(remote_peer_id)
+            self._sync_live_connections_count()
 
         @channel.on("error")
         def on_error(e):
             logging.error(f"[data] Data channel error with {remote_peer_id}: {e}")
+            self._sync_live_connections_count()
 
     def send(self, payload: str, payload_type: str = "text"):
         self.schedule_task(self._send(payload, payload_type))
@@ -611,13 +625,9 @@ class P2PManager(WSInterface):
                     f"{metadata['index'] + 1}/{metadata['totalFragments']}"
                 )
                 if metadata["id"] in self.receiving_fragments:
-                    self.receiving_fragments[metadata["id"]][
-                        metadata["index"]
-                    ] = payload
+                    self.receiving_fragments[metadata["id"]][metadata["index"]] = payload
                     if metadata["index"] == metadata["totalFragments"] - 1:
-                        if all(
-                            s != "" for s in self.receiving_fragments[metadata["id"]]
-                        ):
+                        if all(s != "" for s in self.receiving_fragments[metadata["id"]]):
                             payload = "".join(self.receiving_fragments[metadata["id"]])
                         else:
                             self.reset_receiving_fragments()
@@ -629,12 +639,8 @@ class P2PManager(WSInterface):
                         return
                 else:
                     self.reset_receiving_fragments()
-                    self.receiving_fragments[metadata["id"]] = [""] * metadata[
-                        "totalFragments"
-                    ]
-                    self.receiving_fragments[metadata["id"]][
-                        metadata["index"]
-                    ] = payload
+                    self.receiving_fragments[metadata["id"]] = [""] * metadata["totalFragments"]
+                    self.receiving_fragments[metadata["id"]][metadata["index"]] = payload
                     return
 
             if self.config.data["cipher_enabled"]:
@@ -648,9 +654,7 @@ class P2PManager(WSInterface):
                     base64_string=payload, type_=payload_type
                 )
         except json.decoder.JSONDecodeError:
-            logging.error(
-                "If cipher is enabled, please make sure it is enabled on all devices"
-            )
+            logging.error("If cipher is enabled, please make sure it is enabled on all devices")
         except Exception as e:
             logging.error(f"Failed to receive data: {e}")
 
@@ -693,9 +697,7 @@ class P2PManager(WSInterface):
 
         # 1) Must start with something like "candidate:..."
         if not tokens or not tokens[0].startswith("candidate:"):
-            raise ValueError(
-                "Not a valid ICE candidate line (must start with 'candidate:')."
-            )
+            raise ValueError("Not a valid ICE candidate line (must start with 'candidate:').")
 
         # 2) Basic mandatory fields (RFC 5245)
         #

--- a/ClipCascade_Desktop/src/pyproject.toml
+++ b/ClipCascade_Desktop/src/pyproject.toml
@@ -1,18 +1,26 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=65.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "clipcascade"
-version = "3.1.0"
+name = "ClipCascade"
+version = "3.2.0"
 description = "ClipCascade is a lightweight utility that automatically syncs the clipboard across devices, no key press required."
-authors = [{name = "Sathvik Rao", email = "your.email@example.com"}]
-license = {file = "LICENSE"}
+authors = [{ name = "Sathvik Rao", email = "sathvik.poladi@gmail.com" }]
+license = { file = "LICENSE" }
 requires-python = ">=3.8"
+keywords = [
+    "clipboard",
+    "sync",
+    "cross-platform",
+    "open-source",
+    "utility",
+    "encryption",
+]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: End Users/Desktop",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
@@ -20,21 +28,57 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Topic :: System :: Monitoring",
 ]
 
-dynamic = ["dependencies"]
+dependencies = [
+    "Pillow>=10.4.0",
+    "plyer==2.1.0",
+    "pycryptodome==3.20.0",
+    "pystray==0.19.5",
+    "Requests==2.32.3",
+    "websocket_client==1.8.0",
+    "xxhash==3.5.0",
+    "beautifulsoup4==4.12.3",
+    "aiortc==1.10.0",
+    # Platform-specific dependencies
+    "pyfiglet==1.0.2; sys_platform == 'linux'",
+    "pyperclip==1.8.2; sys_platform == 'win32' or sys_platform == 'darwin'",
+    "pywin32==306; sys_platform == 'win32'",
+    "certifi; sys_platform == 'darwin'",
+    "pyobjus==1.2.3; sys_platform == 'darwin'",
+    "pasteboard==0.4.0; sys_platform == 'darwin'",
+]
 
 [project.scripts]
 clipcascade = "main:main"
 
 [tool.setuptools]
-packages = ["cli", "clipboard", "core", "gui", "interfaces", "p2p", "stomp_ws", "utils"]
 py-modules = ["main"]
+packages = [
+    "cli",
+    "clipboard",
+    "core",
+    "gui",
+    "interfaces",
+    "p2p",
+    "stomp_ws",
+    "utils",
+]
 
-[tool.setuptools.dynamic]
-dependencies = {file = ["requirements_linux.txt"]}
+[tool.black]
+line-length = 100
+target-version = ["py38", "py39", "py310", "py311", "py312"]
+include = "\\.pyi?$"
+
+[tool.isort]
+profile = "black"
+line_length = 100
+multi_line_mode = 3
 
 [project.urls]
 Homepage = "https://clipcascade.sathvik.dev/"
 Repository = "https://github.com/Sathvik-Rao/ClipCascade"
+Documentation = "https://github.com/Sathvik-Rao/ClipCascade#readme"
 Issues = "https://github.com/Sathvik-Rao/ClipCascade/issues"
+Discussions = "https://github.com/Sathvik-Rao/ClipCascade/discussions"

--- a/ClipCascade_Desktop/src/pyproject.toml
+++ b/ClipCascade_Desktop/src/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "clipcascade"
+version = "3.1.0"
+description = "ClipCascade is a lightweight utility that automatically syncs the clipboard across devices, no key press required."
+authors = [{name = "Sathvik Rao", email = "your.email@example.com"}]
+license = {file = "LICENSE"}
+requires-python = ">=3.8"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: End Users/Desktop",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+
+dynamic = ["dependencies"]
+
+[project.scripts]
+clipcascade = "main:main"
+
+[tool.setuptools]
+packages = ["cli", "clipboard", "core", "gui", "interfaces", "p2p", "stomp_ws", "utils"]
+py-modules = ["main"]
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements_linux.txt"]}
+
+[project.urls]
+Homepage = "https://clipcascade.sathvik.dev/"
+Repository = "https://github.com/Sathvik-Rao/ClipCascade"
+Issues = "https://github.com/Sathvik-Rao/ClipCascade/issues"

--- a/ClipCascade_Desktop/src/requirements_mac.txt
+++ b/ClipCascade_Desktop/src/requirements_mac.txt
@@ -10,3 +10,4 @@ websocket_client==1.8.0
 xxhash==3.5.0
 beautifulsoup4==4.12.3
 aiortc==1.10.0
+pyinstaller==6.17.0

--- a/ClipCascade_Desktop/src/requirements_mac.txt
+++ b/ClipCascade_Desktop/src/requirements_mac.txt
@@ -10,4 +10,3 @@ websocket_client==1.8.0
 xxhash==3.5.0
 beautifulsoup4==4.12.3
 aiortc==1.10.0
-pyinstaller==6.17.0

--- a/ClipCascade_Desktop/src/stomp_ws/client.py
+++ b/ClipCascade_Desktop/src/stomp_ws/client.py
@@ -7,18 +7,15 @@ import logging
 
 from core.constants import *
 
-if PLATFORM == MACOS:
-    import ssl
-    import certifi
-
 VERSIONS = "1.0,1.1"
 
 
 class Client:
 
-    def __init__(self, url, headers={}, on_close_callback=None):
+    def __init__(self, url, headers={}, on_close_callback=None, sslopt=None):
 
         self.url = url
+        self._ws_sslopt = sslopt
         self.ws = websocket.WebSocketApp(self.url, headers)
         self.ws.on_open = self._on_open
         self.ws.on_message = self._on_message
@@ -37,10 +34,9 @@ class Client:
         self.errorCallback = None
 
     def _connect(self, timeout=0):
-        if PLATFORM == MACOS:
-            ssl_context = ssl.create_default_context(cafile=certifi.where())
+        if self._ws_sslopt:
             thread = Thread(
-                target=lambda: self.ws.run_forever(sslopt={"context": ssl_context})
+                target=lambda: self.ws.run_forever(sslopt=self._ws_sslopt)
             )
         else:
             thread = Thread(target=self.ws.run_forever)

--- a/ClipCascade_Desktop/src/stomp_ws/stomp_manager.py
+++ b/ClipCascade_Desktop/src/stomp_ws/stomp_manager.py
@@ -10,6 +10,7 @@ from utils.cipher_manager import CipherManager
 from clipboard.clipboard_manager import ClipboardManager
 from utils.notification_manager import NotificationManager
 from utils.request_manager import RequestManager
+from utils.ssl_helper import websocket_sslopt_for_config
 from core.constants import *
 
 if PLATFORM.startswith(LINUX) and LINUX_USE_CLI_UI:
@@ -49,40 +50,42 @@ class STOMPManager(WSInterface):
 
     def connect(self) -> tuple[bool, str]:
         try:
-            if not self.is_connected:
-                self.client = Client(
-                    self.config.data["websocket_url"],
-                    headers={
-                        "Cookie": RequestManager.format_cookie(
-                            self.config.data["cookie"]
-                        )
-                    },
-                    on_close_callback=self._on_close,
-                )
-                self.client.connect(
-                    timeout=WEBSOCKET_TIMEOUT,
-                    connectCallback=lambda _: self.client.subscribe(  # receive event
-                        destination=SUBSCRIPTION_DESTINATION,
-                        callback=self._receive,
-                    ),
-                )
-                if self.disconnected:
-                    self.disconnect()
-                    return False, "Websocket disconnected"
-
-                # logging.info("Websocket connected")
-                self.is_connected = True
-                self.is_auto_reconnecting = False
-                if not self.first_conn_lost:
-                    self.first_conn_lost = True
-                    self.notification_manager.notify(
-                        title=f"{APP_NAME}: WebSocket Connection Restored 🔗",
-                        message="Connection re-established",
+            if self.is_connected:
+                return True, ""
+            self.client = Client(
+                self.config.data["websocket_url"],
+                headers={
+                    "Cookie": RequestManager.format_cookie(
+                        self.config.data["cookie"]
                     )
+                },
+                on_close_callback=self._on_close,
+                sslopt=websocket_sslopt_for_config(self.config),
+            )
+            self.client.connect(
+                timeout=WEBSOCKET_TIMEOUT,
+                connectCallback=lambda _: self.client.subscribe(  # receive event
+                    destination=SUBSCRIPTION_DESTINATION,
+                    callback=self._receive,
+                ),
+            )
+            if self.disconnected:
+                self.disconnect()
+                return False, "Websocket disconnected"
 
-                # send event
-                self.clipboard_manager.on_copy(self.send)
-                return True, "Websocket connected"
+            # logging.info("Websocket connected")
+            self.is_connected = True
+            self.is_auto_reconnecting = False
+            if not self.first_conn_lost:
+                self.first_conn_lost = True
+                self.notification_manager.notify(
+                    title=f"{APP_NAME}: WebSocket Connection Restored 🔗",
+                    message="Connection re-established",
+                )
+
+            # send event
+            self.clipboard_manager.on_copy(self.send)
+            return True, "Websocket connected"
         except Exception as e:
             msg = f"Failed to connect websocket: {e}"
             logging.error(msg)

--- a/ClipCascade_Desktop/src/stomp_ws/stomp_manager.py
+++ b/ClipCascade_Desktop/src/stomp_ws/stomp_manager.py
@@ -12,7 +12,7 @@ from utils.notification_manager import NotificationManager
 from utils.request_manager import RequestManager
 from core.constants import *
 
-if PLATFORM.startswith(LINUX) and not XMODE:
+if PLATFORM.startswith(LINUX) and LINUX_USE_CLI_UI:
     from cli.tray import TaskbarPanel
 else:
     from gui.tray import TaskbarPanel

--- a/ClipCascade_Desktop/src/utils/notification_manager.py
+++ b/ClipCascade_Desktop/src/utils/notification_manager.py
@@ -1,10 +1,12 @@
 from core.constants import *
 from core.config import Config
 
-if PLATFORM == WINDOWS or (PLATFORM.startswith(LINUX) and XMODE):
+if PLATFORM == WINDOWS or (
+    PLATFORM.startswith(LINUX) and not LINUX_USE_CLI_UI
+):
     # WINDOWS: When creating the executable with pyinstaller, add --hidden-import plyer.platforms.win.notification
     from plyer import notification
-elif PLATFORM.startswith(LINUX) and not XMODE:
+elif PLATFORM.startswith(LINUX) and LINUX_USE_CLI_UI:
     from cli.info import CustomDialog
 elif PLATFORM == MACOS:
     import subprocess
@@ -17,14 +19,16 @@ class NotificationManager:
     def notify(self, title: str, message: str, app_name: str = APP_NAME, timeout=10):
         if self.config.data["notification"]:  # Check if notifications are enabled
             try:
-                if PLATFORM == WINDOWS or PLATFORM.startswith(LINUX) and XMODE:
+                if PLATFORM == WINDOWS or (
+                    PLATFORM.startswith(LINUX) and not LINUX_USE_CLI_UI
+                ):
                     notification.notify(
                         title=title,
                         message=message,
                         app_name=app_name,
                         timeout=timeout,  # seconds
                     )
-                elif PLATFORM.startswith(LINUX) and not XMODE:
+                elif PLATFORM.startswith(LINUX) and LINUX_USE_CLI_UI:
                     CustomDialog(f"{title} : {message}").mainloop()
                 elif PLATFORM == MACOS:
                     subprocess.run(

--- a/ClipCascade_Desktop/src/utils/request_manager.py
+++ b/ClipCascade_Desktop/src/utils/request_manager.py
@@ -4,11 +4,15 @@ import requests
 from core.constants import *
 from core.config import Config
 from bs4 import BeautifulSoup
+from utils.ssl_helper import requests_verify_arg
 
 
 class RequestManager:
     def __init__(self, config: Config):
         self.config = config
+
+    def _verify(self):
+        return requests_verify_arg(self.config)
 
     @staticmethod
     def format_cookie(cookie: dict) -> str:
@@ -22,7 +26,10 @@ class RequestManager:
             session = requests.Session()
 
             # Fetch the login page to get the CSRF token
-            response = session.get(self.config.data["server_url"] + LOGIN_URL)
+            response = session.get(
+                self.config.data["server_url"] + LOGIN_URL,
+                verify=self._verify(),
+            )
 
             if response.status_code != 200:
                 msg = f"Failed to fetch login page: {response.status_code}"
@@ -41,6 +48,7 @@ class RequestManager:
             response = session.post(
                 self.config.data["server_url"] + LOGIN_URL,
                 data=form_data,
+                verify=self._verify(),
             )
             if (
                 response.status_code == 200
@@ -67,6 +75,7 @@ class RequestManager:
                 headers={
                     "Cookie": RequestManager.format_cookie(self.config.data["cookie"])
                 },
+                verify=self._verify(),
             )
             if response.status_code == 200:
                 # maxsize request successful
@@ -86,6 +95,7 @@ class RequestManager:
                 headers={
                     "Cookie": RequestManager.format_cookie(self.config.data["cookie"])
                 },
+                verify=self._verify(),
             )
             if response.status_code == 200:
                 # server mode request successful
@@ -103,6 +113,7 @@ class RequestManager:
                 headers={
                     "Cookie": RequestManager.format_cookie(self.config.data["cookie"])
                 },
+                verify=self._verify(),
             )
             if response.status_code == 200:
                 # stun url request successful
@@ -120,6 +131,7 @@ class RequestManager:
                 headers={
                     "Cookie": RequestManager.format_cookie(self.config.data["cookie"])
                 },
+                verify=True,
             )
             if response.status_code == 200:
                 # metadata request successful
@@ -136,6 +148,7 @@ class RequestManager:
                 headers={
                     "Cookie": RequestManager.format_cookie(self.config.data["cookie"])
                 },
+                verify=self._verify(),
             )
             if response.status_code == 204:
                 logging.info(f"Logout successful: {response.status_code}")
@@ -149,6 +162,7 @@ class RequestManager:
                 headers={
                     "Cookie": RequestManager.format_cookie(self.config.data["cookie"])
                 },
+                verify=self._verify(),
             )
 
             if response.status_code == 200:
@@ -159,12 +173,12 @@ class RequestManager:
             return ""
 
     @staticmethod
-    def get(url: str, headers: dict = None) -> requests.Response:
+    def get(url: str, headers: dict = None, verify=True) -> requests.Response:
         """
         A generic GET mapper for handling GET requests.
         """
         try:
-            response = requests.get(url, headers=headers)
+            response = requests.get(url, headers=headers, verify=verify)
             response.raise_for_status()  # Will raise an HTTPError if the HTTP request returned an unsuccessful status code
             return response
         except Exception as e:
@@ -172,12 +186,14 @@ class RequestManager:
             raise
 
     @staticmethod
-    def post(url: str, data: dict, headers: dict = None) -> requests.Response:
+    def post(
+        url: str, data: dict, headers: dict = None, verify=True
+    ) -> requests.Response:
         """
         A generic POST mapper for handling POST requests.
         """
         try:
-            response = requests.post(url, data=data, headers=headers)
+            response = requests.post(url, data=data, headers=headers, verify=verify)
             response.raise_for_status()  # Will raise an HTTPError if the HTTP request returned an unsuccessful status code
             return response
         except Exception as e:

--- a/ClipCascade_Desktop/src/utils/ssl_helper.py
+++ b/ClipCascade_Desktop/src/utils/ssl_helper.py
@@ -1,0 +1,32 @@
+import os
+import ssl
+from typing import Any, Dict, Optional, Union
+
+from core.constants import MACOS, PLATFORM
+
+if PLATFORM == MACOS:
+    import certifi
+
+
+def requests_verify_arg(config) -> Union[bool, str]:
+    """Argument for requests' verify= when calling the user's server."""
+    path = (config.data.get("ssl_ca_bundle") or "").strip()
+    if not path:
+        return True
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"SSL CA bundle file not found: {path}")
+    return path
+
+
+def websocket_sslopt_for_config(config) -> Optional[Dict[str, Any]]:
+    """sslopt for websocket_client run_forever; None uses the library/OS default."""
+    path = (config.data.get("ssl_ca_bundle") or "").strip()
+    if path:
+        if not os.path.isfile(path):
+            raise FileNotFoundError(f"SSL CA bundle file not found: {path}")
+        ctx = ssl.create_default_context(cafile=path)
+        return {"context": ctx}
+    if PLATFORM == MACOS:
+        ctx = ssl.create_default_context(cafile=certifi.where())
+        return {"context": ctx}
+    return None

--- a/ClipCascade_Desktop/src/utils/window_manager.py
+++ b/ClipCascade_Desktop/src/utils/window_manager.py
@@ -1,0 +1,81 @@
+import re
+from core.constants import *
+
+def center_window(win, max_height=None):
+    """Center a Tk/Toplevel window on the primary monitor."""
+    win.update_idletasks()
+
+    window_width = win.winfo_width()
+    window_height = win.winfo_height()
+    if max_height:
+        window_height = min(window_height, max_height)
+
+    primary_x, primary_y = 0, 0
+    primary_w, primary_h = win.winfo_screenwidth(), win.winfo_screenheight()
+
+    try:
+        if PLATFORM == WINDOWS:
+            import ctypes
+            from ctypes import wintypes
+
+            user32 = ctypes.windll.user32
+            try:
+                user32.SetProcessDPIAware()
+            except Exception:
+                pass
+
+            monitors = []
+
+            MONITORENUMPROC = ctypes.WINFUNCTYPE(
+                wintypes.BOOL,
+                wintypes.HMONITOR,
+                wintypes.HDC,
+                ctypes.POINTER(wintypes.RECT),
+                wintypes.LPARAM,
+            )
+
+            def _monitor_cb(hMonitor, hdcMonitor, lprcMonitor, dwData):
+                rc = lprcMonitor.contents
+                monitors.append((rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top))
+                return True
+
+            user32.EnumDisplayMonitors(None, None, MONITORENUMPROC(_monitor_cb), 0)
+
+            for mx, my, mw, mh in monitors:
+                if mx == 0 and my == 0:
+                    primary_x, primary_y, primary_w, primary_h = mx, my, mw, mh
+                    break
+
+        elif PLATFORM == MACOS:
+            from AppKit import NSScreen
+            screen = NSScreen.mainScreen()
+            frame = screen.frame()
+            primary_x = int(frame.origin.x)
+            primary_y = int(frame.origin.y)
+            primary_w = int(frame.size.width)
+            primary_h = int(frame.size.height)
+
+        elif PLATFORM.startswith(LINUX):
+            import subprocess
+            result = subprocess.run(
+                ["xrandr", "--query"], capture_output=True, text=True, timeout=2
+            )
+            for line in result.stdout.splitlines():
+                if " connected primary" in line:
+                    m = re.search(r"(\d+)x(\d+)\+(\d+)\+(\d+)", line)
+                    if m:
+                        primary_w = int(m.group(1))
+                        primary_h = int(m.group(2))
+                        primary_x = int(m.group(3))
+                        primary_y = int(m.group(4))
+                    break
+    except Exception:
+        pass
+
+    x = primary_x + (primary_w - window_width) // 2
+    y = primary_y + (primary_h - window_height) // 2
+
+    x = max(primary_x, x)
+    y = max(primary_y, y)
+
+    win.geometry(f"{window_width}x{window_height}+{x}+{y}")

--- a/ClipCascade_Desktop/src/utils/window_manager.py
+++ b/ClipCascade_Desktop/src/utils/window_manager.py
@@ -1,62 +1,24 @@
+import logging
 import re
 from core.constants import *
 
+
 def center_window(win, max_height=None):
     """Center a Tk/Toplevel window on the primary monitor."""
+    logging.debug(f"Centering window with max_height={max_height}")
     win.update_idletasks()
-
     window_width = win.winfo_width()
     window_height = win.winfo_height()
     if max_height:
         window_height = min(window_height, max_height)
-
+    logging.debug(f"Window dimensions: {window_width}x{window_height}")
     primary_x, primary_y = 0, 0
     primary_w, primary_h = win.winfo_screenwidth(), win.winfo_screenheight()
-
     try:
-        if PLATFORM == WINDOWS:
-            import ctypes
-            from ctypes import wintypes
-
-            user32 = ctypes.windll.user32
-            try:
-                user32.SetProcessDPIAware()
-            except Exception:
-                pass
-
-            monitors = []
-
-            MONITORENUMPROC = ctypes.WINFUNCTYPE(
-                wintypes.BOOL,
-                wintypes.HMONITOR,
-                wintypes.HDC,
-                ctypes.POINTER(wintypes.RECT),
-                wintypes.LPARAM,
-            )
-
-            def _monitor_cb(hMonitor, hdcMonitor, lprcMonitor, dwData):
-                rc = lprcMonitor.contents
-                monitors.append((rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top))
-                return True
-
-            user32.EnumDisplayMonitors(None, None, MONITORENUMPROC(_monitor_cb), 0)
-
-            for mx, my, mw, mh in monitors:
-                if mx == 0 and my == 0:
-                    primary_x, primary_y, primary_w, primary_h = mx, my, mw, mh
-                    break
-
-        elif PLATFORM == MACOS:
-            from AppKit import NSScreen
-            screen = NSScreen.mainScreen()
-            frame = screen.frame()
-            primary_x = int(frame.origin.x)
-            primary_y = int(frame.origin.y)
-            primary_w = int(frame.size.width)
-            primary_h = int(frame.size.height)
-
-        elif PLATFORM.startswith(LINUX):
+        if PLATFORM.startswith(LINUX):
+            logging.debug("Detecting monitors on Linux platform")
             import subprocess
+
             result = subprocess.run(
                 ["xrandr", "--query"], capture_output=True, text=True, timeout=2
             )
@@ -68,14 +30,16 @@ def center_window(win, max_height=None):
                         primary_h = int(m.group(2))
                         primary_x = int(m.group(3))
                         primary_y = int(m.group(4))
+                        logging.debug(
+                            f"Primary monitor: position=({primary_x}, {primary_y}), size={primary_w}x{primary_h}"
+                        )
                     break
-    except Exception:
-        pass
-
+    except Exception as e:
+        logging.warning(f"Failed to detect primary monitor: {e}. Using fallback dimensions.")
     x = primary_x + (primary_w - window_width) // 2
     y = primary_y + (primary_h - window_height) // 2
-
     x = max(primary_x, x)
     y = max(primary_y, y)
-
+    logging.debug(f"Calculated window position: ({x}, {y})")
     win.geometry(f"{window_width}x{window_height}+{x}+{y}")
+    logging.debug(f"Applied geometry: {window_width}x{window_height}+{x}+{y}")

--- a/ClipCascade_Mobile/src/App.js
+++ b/ClipCascade_Mobile/src/App.js
@@ -509,7 +509,7 @@ export default function App() {
         if (!serverModeResponse.ok) {
           return [
             false,
-            'Login Successful but unable to get server mode \n Status: ' +
+            'Login Successful but unable to get server mode; Status: ' +
               serverModeResponse.status,
             data_s,
           ];
@@ -530,7 +530,7 @@ export default function App() {
           if (!stunUrlResponse.ok) {
             return [
               false,
-              'Login Successful but unable to get stun url \n Status: ' +
+              'Login Successful but unable to get stun url; Status: ' +
                 stunUrlResponse.status,
               data_s,
             ];
@@ -556,7 +556,7 @@ export default function App() {
           if (!maxSizeResponse.ok) {
             return [
               false,
-              'Login Successful but unable to get max size \n Status: ' +
+              'Login Successful but unable to get max size; Status: ' +
                 maxSizeResponse.status,
               data_s,
             ];

--- a/ClipCascade_Mobile/src/App.js
+++ b/ClipCascade_Mobile/src/App.js
@@ -60,7 +60,7 @@ import StartForegroundService from './StartForegroundService';
  */
 
 // App version
-const APP_VERSION = '3.1.0';
+const APP_VERSION = '3.2.0';
 
 // Main App
 export default function App() {

--- a/ClipCascade_Mobile/src/StartForegroundService.js
+++ b/ClipCascade_Mobile/src/StartForegroundService.js
@@ -222,9 +222,9 @@ module.exports = async (inputData = null) => {
               'wsStatusMessage',
               '⚠️ ' +
                 direction +
-                ' clipboard ignored: \n size (' +
+                ' clipboard ignored: size (' +
                 clipContentByteLength +
-                ' bytes) exceeds limits: \n Server max size (' +
+                ' bytes) exceeds limits; Server max size (' +
                 maxsize +
                 ' bytes) or Local max size (' +
                 max_clipboard_size_local_limit_bytes +
@@ -241,9 +241,9 @@ module.exports = async (inputData = null) => {
             p2pMsg =
               '⚠️ ' +
               direction +
-              ' clipboard ignored: \n size (' +
+              ' clipboard ignored: size (' +
               clipContentByteLength +
-              ' bytes) exceeds limits: \n Local max size (' +
+              ' bytes) exceeds limits; Local max size (' +
               max_clipboard_size_local_limit_bytes +
               ' bytes)';
             await p2pStatusMessageChanged();
@@ -640,7 +640,7 @@ module.exports = async (inputData = null) => {
               msg += ` | Receiving: ${receivingFragmentStats}`;
             }
             if (p2pMsg != null) {
-              msg += `\n${p2pMsg}`;
+              msg += ` | ${p2pMsg}`;
             }
             return msg;
           };

--- a/ClipCascade_Mobile/src/StartForegroundService.js
+++ b/ClipCascade_Mobile/src/StartForegroundService.js
@@ -618,6 +618,7 @@ module.exports = async (inputData = null) => {
           let peerConnections = {}; // Map: peerId -> RTCPeerConnection
           let dataChannels = {}; // Map: peerId -> RTCDataChannel
           let liveConnectionsCount = 0; // Track open DataChannels
+          let pendingPeerList = null;
           let p2pShuttingDown = false;
           const peerOpChains = {};
           const dataChannelHeartbeatTimers = {};
@@ -728,6 +729,7 @@ module.exports = async (inputData = null) => {
               peerConnections = {};
 
               myPeerId = null;
+              pendingPeerList = null;
               peers.clear();
               liveConnectionsCount = 0;
               for (const k of Object.keys(peerOpChains)) {
@@ -772,6 +774,11 @@ module.exports = async (inputData = null) => {
                         await cleanupPeerConnections();
                       }
                       myPeerId = data.peerId;
+                      if (pendingPeerList != null) {
+                        const pending = pendingPeerList;
+                        pendingPeerList = null;
+                        await handlePeerList(pending);
+                      }
                       break;
 
                     case 'PEER_LIST':
@@ -1129,6 +1136,10 @@ module.exports = async (inputData = null) => {
            * For each peer, create a PeerConnection if we don't have one yet.
            */
           const handlePeerList = async peerList => {
+            if (!myPeerId) {
+              pendingPeerList = Array.isArray(peerList) ? [...peerList] : [];
+              return;
+            }
             const updatedPeers = new Set(peerList);
             peers = updatedPeers;
             await removeStalePeers(updatedPeers);

--- a/ClipCascade_Mobile/src/StartForegroundService.js
+++ b/ClipCascade_Mobile/src/StartForegroundService.js
@@ -483,7 +483,7 @@ module.exports = async (inputData = null) => {
             },
             onWebSocketClose: async event => {
               block_image_once = false;
-              const reason = evt?.reason || 'closed by client';
+              const reason = event?.reason || 'closed by client';
               await setDataInAsyncStorage(
                 'wsStatusMessage',
                 `⚠️ WebSocket Close: ${reason}`,
@@ -618,6 +618,10 @@ module.exports = async (inputData = null) => {
           let peerConnections = {}; // Map: peerId -> RTCPeerConnection
           let dataChannels = {}; // Map: peerId -> RTCDataChannel
           let liveConnectionsCount = 0; // Track open DataChannels
+          let p2pShuttingDown = false;
+          const peerOpChains = {};
+          const dataChannelHeartbeatTimers = {};
+          const P2P_DC_KEEPALIVE_JSON = JSON.stringify({ _cc_keepalive: true });
 
           // Fragment variables
           let sendingFragmentId = '';
@@ -657,11 +661,92 @@ module.exports = async (inputData = null) => {
             await p2pStatusMessageChanged();
           };
 
+          const syncLiveConnectionsCount = async () => {
+            liveConnectionsCount = Object.values(dataChannels).filter(
+              c => c && c.readyState === 'open',
+            ).length;
+            isP2PStatusMsgChanged = true;
+            await p2pStatusMessageChanged();
+          };
+
+          const runSerializedPeerOp = (peerId, op) => {
+            const prev = peerOpChains[peerId] || Promise.resolve();
+            const next = prev.then(() => op()).catch(() => {});
+            peerOpChains[peerId] = next;
+            return next;
+          };
+
+          const startDataChannelHeartbeat = (remotePeerId, channel) => {
+            if (dataChannelHeartbeatTimers[remotePeerId]) {
+              clearInterval(dataChannelHeartbeatTimers[remotePeerId]);
+            }
+            dataChannelHeartbeatTimers[remotePeerId] = setInterval(() => {
+              try {
+                if (channel.readyState === 'open') {
+                  channel.send(P2P_DC_KEEPALIVE_JSON);
+                }
+              } catch (e) {
+                // no-op
+              }
+            }, HEARTBEAT_INTERVAL);
+          };
+
+          async function cleanupPeerConnections() {
+            p2pShuttingDown = true;
+            try {
+              for (const id of Object.keys(dataChannelHeartbeatTimers)) {
+                clearInterval(dataChannelHeartbeatTimers[id]);
+                delete dataChannelHeartbeatTimers[id];
+              }
+              for (const [, dc] of Object.entries(dataChannels)) {
+                if (dc) {
+                  try {
+                    dc.onopen = null;
+                    dc.onmessage = null;
+                    dc.onclose = null;
+                    dc.onerror = null;
+                    dc.close();
+                  } catch (e) {
+                    // no-op
+                  }
+                }
+              }
+              dataChannels = {};
+
+              for (const [, pc] of Object.entries(peerConnections)) {
+                if (pc) {
+                  try {
+                    pc.onicecandidate = null;
+                    pc.ondatachannel = null;
+                    pc.onconnectionstatechange = null;
+                    pc.close();
+                  } catch (e) {
+                    // no-op
+                  }
+                }
+              }
+              peerConnections = {};
+
+              myPeerId = null;
+              peers.clear();
+              liveConnectionsCount = 0;
+              for (const k of Object.keys(peerOpChains)) {
+                delete peerOpChains[k];
+              }
+              await resetReceivingFragments();
+              await resetSendingFragmentId();
+            } finally {
+              p2pShuttingDown = false;
+            }
+          }
+
           const initializeWebSocketSignalingClient = async () => {
             if (wsSignalingClient == null) {
               wsSignalingClient = new WebSocket(websocket_url);
 
               wsSignalingClient.onopen = async () => {
+                await cleanupPeerConnections();
+
                 await setDataInAsyncStorage('wsStatusMessage', '✅ Connected');
 
                 if (enable_websocket_status_notification === 'true') {
@@ -928,10 +1013,14 @@ module.exports = async (inputData = null) => {
           // receive clipboard content P2P
           const onDataChannelMessage = async messageJson => {
             try {
+              const message = JSON.parse(messageJson);
+              if (message && message._cc_keepalive === true) {
+                return;
+              }
+
               await clearFiles((expensiveCall = true));
               await resetSendingFragmentId();
 
-              const message = JSON.parse(messageJson);
               let cb = String(message.payload);
               const type_ = message.type ?? 'text';
               const metadata = message.metadata;
@@ -1035,55 +1124,15 @@ module.exports = async (inputData = null) => {
             }
           };
 
-          const cleanupPeerConnections = async () => {
-            // 1) Close all DataChannels
-            for (const [peerId, dc] of Object.entries(dataChannels)) {
-              if (dc) {
-                try {
-                  dc.onopen = null;
-                  dc.onmessage = null;
-                  dc.onclose = null;
-                  dc.onerror = null;
-                  dc.close();
-                } catch (e) {
-                  // no-op
-                }
-              }
-            }
-            dataChannels = {};
-
-            // 2) Close all RTCPeerConnections
-            for (const [peerId, pc] of Object.entries(peerConnections)) {
-              if (pc) {
-                try {
-                  pc.onicecandidate = null;
-                  pc.ondatachannel = null;
-                  pc.close();
-                } catch (e) {
-                  // no-op
-                }
-              }
-            }
-            peerConnections = {};
-
-            // 3) Reset local P2P state as needed
-            myPeerId = null;
-            peers.clear();
-            liveConnectionsCount = 0;
-            await resetReceivingFragments();
-            await resetSendingFragmentId();
-          };
-
           /**
            * The server gave us the entire list of peers in the "room".
            * For each peer, create a PeerConnection if we don't have one yet.
            */
           const handlePeerList = async peerList => {
             const updatedPeers = new Set(peerList);
-
+            peers = updatedPeers;
             await removeStalePeers(updatedPeers);
 
-            peers = updatedPeers;
             peers.forEach(async pid => {
               if (pid === myPeerId) return; // skip self
               if (!peerConnections[pid]) {
@@ -1112,13 +1161,13 @@ module.exports = async (inputData = null) => {
             );
             // 2) For each stale peer, close data channel and peer connection
             for (const oldPid of stalePeerIds) {
-              // Close and remove its data channel
+              delete peerOpChains[oldPid];
+              if (dataChannelHeartbeatTimers[oldPid]) {
+                clearInterval(dataChannelHeartbeatTimers[oldPid]);
+                delete dataChannelHeartbeatTimers[oldPid];
+              }
               if (dataChannels[oldPid]) {
                 try {
-                  if (dataChannels[oldPid].readyState === 'open') {
-                    liveConnectionsCount--;
-                    await p2pStatusMessageChanged();
-                  }
                   dataChannels[oldPid].onopen = null;
                   dataChannels[oldPid].onmessage = null;
                   dataChannels[oldPid].onclose = null;
@@ -1128,16 +1177,50 @@ module.exports = async (inputData = null) => {
                 delete dataChannels[oldPid];
               }
 
-              // Close and remove its RTCPeerConnection
               if (peerConnections[oldPid]) {
                 try {
                   peerConnections[oldPid].onicecandidate = null;
                   peerConnections[oldPid].ondatachannel = null;
+                  peerConnections[oldPid].onconnectionstatechange = null;
                   peerConnections[oldPid].close();
                 } catch (err) {}
                 delete peerConnections[oldPid];
               }
             }
+            await syncLiveConnectionsCount();
+          };
+
+          const disposePeerConnection = async peerId => {
+            if (dataChannelHeartbeatTimers[peerId]) {
+              clearInterval(dataChannelHeartbeatTimers[peerId]);
+              delete dataChannelHeartbeatTimers[peerId];
+            }
+            const dc = dataChannels[peerId];
+            if (dc) {
+              try {
+                dc.onopen = null;
+                dc.onmessage = null;
+                dc.onclose = null;
+                dc.onerror = null;
+                dc.close();
+              } catch (e) {
+                // no-op
+              }
+              delete dataChannels[peerId];
+            }
+            const pc = peerConnections[peerId];
+            if (pc) {
+              try {
+                pc.onicecandidate = null;
+                pc.ondatachannel = null;
+                pc.onconnectionstatechange = null;
+                pc.close();
+              } catch (e) {
+                // no-op
+              }
+              delete peerConnections[peerId];
+            }
+            await syncLiveConnectionsCount();
           };
 
           /**
@@ -1152,7 +1235,6 @@ module.exports = async (inputData = null) => {
               ],
             });
 
-            // This fires when the local side gathers an ICE candidate
             pc.onicecandidate = async event => {
               if (event.candidate) {
                 await signalingSend({
@@ -1164,11 +1246,17 @@ module.exports = async (inputData = null) => {
               }
             };
 
-            // This fires when the remote side creates a datachannel
             pc.ondatachannel = async event => {
               const channel = event.channel;
               dataChannels[remotePeerId] = channel;
               await setupDataChannel(remotePeerId, channel);
+            };
+
+            pc.onconnectionstatechange = () => {
+              const st = pc.connectionState;
+              if (st === 'failed' || st === 'closed') {
+                recoverPeerTransport(remotePeerId, pc);
+              }
             };
 
             return pc;
@@ -1190,25 +1278,79 @@ module.exports = async (inputData = null) => {
             });
           };
 
+          const recoverPeerTransport = async (remotePeerId, deadPc) => {
+            if (p2pShuttingDown || !myPeerId || !peers.has(remotePeerId)) {
+              return;
+            }
+            if (deadPc != null && peerConnections[remotePeerId] !== deadPc) {
+              return;
+            }
+            await runSerializedPeerOp(remotePeerId, async () => {
+              if (p2pShuttingDown || !myPeerId || !peers.has(remotePeerId)) {
+                return;
+              }
+              if (deadPc != null && peerConnections[remotePeerId] !== deadPc) {
+                return;
+              }
+              if (deadPc == null) {
+                const ch = dataChannels[remotePeerId];
+                if (ch && ch.readyState === 'open') {
+                  return;
+                }
+              }
+              await disposePeerConnection(remotePeerId);
+              if (p2pShuttingDown || !myPeerId || !peers.has(remotePeerId)) {
+                return;
+              }
+              const newPc = await createPeerConnection(remotePeerId);
+              peerConnections[remotePeerId] = newPc;
+              if (myPeerId < remotePeerId) {
+                const channel = await newPc.createDataChannel('cliptext');
+                dataChannels[remotePeerId] = channel;
+                await setupDataChannel(remotePeerId, channel);
+                await createOffer(remotePeerId);
+              }
+            });
+          };
+
           /**
            * Handle incoming OFFER from remote, then respond with ANSWER.
            */
           const handleOffer = async (fromPeerId, offer) => {
-            let pc = peerConnections[fromPeerId];
-            if (!pc) {
-              pc = await createPeerConnection(fromPeerId);
-              peerConnections[fromPeerId] = pc;
+            if (p2pShuttingDown) {
+              return;
             }
+            // Ignore delayed/stale OFFERs for peers removed from the latest PEER_LIST.
+            // Startup guard: allow early signaling before ASSIGNED_ID/PEER_LIST is ready.
+            if (myPeerId && peers.size > 0 && !peers.has(fromPeerId)) {
+              return;
+            }
+            await runSerializedPeerOp(fromPeerId, async () => {
+              if (p2pShuttingDown) {
+                return;
+              }
+              // TOCTOU guard: PEER_LIST can change after the outer fast-path check.
+              if (myPeerId && peers.size > 0 && !peers.has(fromPeerId)) {
+                return;
+              }
+              // Full new offer (e.g. after peer recovery): must not apply on an
+              // existing connected PC or datachannel counts diverge across devices.
+              if (peerConnections[fromPeerId]) {
+                await disposePeerConnection(fromPeerId);
+              }
+              const pc = await createPeerConnection(fromPeerId);
+              peerConnections[fromPeerId] = pc;
 
-            await pc.setRemoteDescription(new RTCSessionDescription(offer));
-            const answer = await pc.createAnswer();
-            await pc.setLocalDescription(answer);
+              await pc.setRemoteDescription(new RTCSessionDescription(offer));
+              const answer = await pc.createAnswer();
+              await pc.setLocalDescription(answer);
 
-            await signalingSend({
-              type: 'ANSWER',
-              fromPeerId: myPeerId,
-              toPeerId: fromPeerId,
-              answer: pc.localDescription,
+              await signalingSend({
+                type: 'ANSWER',
+                fromPeerId: myPeerId,
+                toPeerId: fromPeerId,
+                answer: pc.localDescription,
+              });
             });
           };
 
@@ -1218,6 +1360,12 @@ module.exports = async (inputData = null) => {
           const handleAnswer = async (fromPeerId, answer) => {
             const pc = peerConnections[fromPeerId];
             if (!pc) {
+              return;
+            }
+            if (
+              pc.connectionState === 'failed' ||
+              pc.connectionState === 'closed'
+            ) {
               return;
             }
 
@@ -1232,6 +1380,12 @@ module.exports = async (inputData = null) => {
             if (!pc) {
               return;
             }
+            if (
+              pc.connectionState === 'failed' ||
+              pc.connectionState === 'closed'
+            ) {
+              return;
+            }
 
             await pc.addIceCandidate(new RTCIceCandidate(candidateData));
           };
@@ -1241,8 +1395,8 @@ module.exports = async (inputData = null) => {
            */
           const setupDataChannel = async (remotePeerId, channel) => {
             channel.onopen = async () => {
-              liveConnectionsCount++;
-              await p2pStatusMessageChanged();
+              startDataChannelHeartbeat(remotePeerId, channel);
+              await syncLiveConnectionsCount();
             };
 
             channel.onmessage = async e => {
@@ -1250,14 +1404,23 @@ module.exports = async (inputData = null) => {
             };
 
             channel.onclose = async () => {
-              liveConnectionsCount--;
-              await p2pStatusMessageChanged();
+              if (dataChannelHeartbeatTimers[remotePeerId]) {
+                clearInterval(dataChannelHeartbeatTimers[remotePeerId]);
+                delete dataChannelHeartbeatTimers[remotePeerId];
+              }
+              await syncLiveConnectionsCount();
+              await recoverPeerTransport(remotePeerId, null);
             };
 
             channel.onerror = async err => {
               p2pMsg = '❌ DataChannel error with ' + remotePeerId + ': ' + err;
               await p2pStatusMessageChanged();
             };
+
+            if (channel.readyState === 'open') {
+              startDataChannelHeartbeat(remotePeerId, channel);
+              await syncLiveConnectionsCount();
+            }
           };
         }
 

--- a/ClipCascade_Mobile/src/StartForegroundService.js
+++ b/ClipCascade_Mobile/src/StartForegroundService.js
@@ -820,9 +820,10 @@ module.exports = async (inputData = null) => {
 
               wsSignalingClient.onclose = async event => {
                 block_image_once = false;
+                const reason = event?.reason || 'closed by client';
                 await setDataInAsyncStorage(
                   'wsStatusMessage',
-                  '⚠️ WebSocket Close: ' + event.reason,
+                  '⚠️ WebSocket Close: ' + reason,
                 );
                 if (
                   enable_websocket_status_notification === 'true' &&

--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ To install the ClipCascade Windows desktop application, follow these steps:
 
 To build your own desktop executable from source (`ClipCascade_Desktop/src`):
 ```bash
+pip3 install -r requirements_win.txt
 python3 -m PyInstaller ClipCascade_win.spec
 ```
 
@@ -335,6 +336,7 @@ To install the ClipCascade macOS desktop application, follow these steps:
 
 To build your own desktop executable from source (`ClipCascade_Desktop/src`):
 ```bash
+pip3 install -r requirements_mac.txt
 python3 -m PyInstaller ClipCascade_macos.spec
 ```
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,6 @@ To install the ClipCascade Windows desktop application, follow these steps:
     - When prompted, enter your **server's IP address, port number, or domain name**.
     - If encryption is enabled, ensure it is **enabled on all devices**.
     - In the **Extra Config** section, you can set a local clipboard size limit. By default, no limit is enforced (note: large file transfers may cause temporary unresponsiveness).
-    - In the **Extra Config** section, you can optionally set **SSL CA bundle** to a PEM file path if your server uses a private/internal CA.
 4. **Network Access Prompt (P2P Mode)**
     - If the server is running in **P2P mode**, you will see a Windows security prompt asking, **"Do you want to allow public and private networks to access this app?"**
 
@@ -313,7 +312,6 @@ To install the ClipCascade macOS desktop application, follow these steps:
     - When prompted, enter your **server's IP address, port number, or domain name**.
     - If encryption is enabled, ensure it is **enabled on all devices**.
     - In the **Extra Config** section, you can set a local clipboard size limit. By default, no limit is enforced (note: large file transfers may cause temporary unresponsiveness).
-    - In the **Extra Config** section, you can optionally set **SSL CA bundle** to a PEM file path if your server uses a private/internal CA.
 
 7. **Network Access Prompt (P2P Mode)**
     - If the server is running in **P2P mode**, you will see a macOS security prompt asking, **"Allow "ClipCascade" to find devices on local networks?"**
@@ -497,7 +495,6 @@ Start ClipCascade by running (use sudo if needed):
    - When prompted, enter your **server's IP address, port number, or domain name**.
    - If encryption is enabled, ensure it is **enabled on all devices**.
    - In the **Extra Config** section, you can set a local clipboard size limit. By default, no limit is enforced (note: large file transfers may cause temporary unresponsiveness).
-   - In the **Extra Config** section, you can optionally set **SSL CA bundle** to a PEM file path if your server uses a private/internal CA.
 ```
 python3 main.py
 ```
@@ -1070,7 +1067,7 @@ Defines the STOMP broker password for external message handling.
 
   #### Desktop (Specific):
   - **Default File Download Location**: When this path is set, the app will save files directly to the specified location without prompting the user each time the "Download Files" button is clicked.
-  - **SSL CA bundle (optional)**: Path to a PEM file containing your root CA (or full chain) used for HTTPS/WSS verification. Leave it empty to use default public CA/OS trust. Use this field when your ClipCascade server certificate is signed by a private/internal CA (for example, corporate PKI).
+  - **SSL CA bundle**: Path to a PEM file containing your root CA (or full chain) used for HTTPS/WSS verification. Leave it empty to use default public CA/OS trust. Use this field when your ClipCascade server certificate is signed by a private/internal CA (for example, corporate PKI).
   
   #### Android (Specific):
   - **Run on System Startup**: Enable this option to allow the app to automatically start on system reboot. By default, this option is disabled. If you are using the [ADB](https://github.com/Sathvik-Rao/ClipCascade?tab=readme-ov-file#adb-commands) workaround, keep this option disabled to avoid issues with the READ_LOGS permission [popup](https://github.com/Sathvik-Rao/ClipCascade?tab=readme-ov-file#adb-commands) being dismissed, which prevents clipboard monitoring in the background.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
     </td>
     <td>
       <a href="https://github.com/Sathvik-Rao/ClipCascade/releases">
-        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/5f/Windows_logo_-_2012.svg/512px-Windows_logo_-_2012.svg.png" alt="Windows" width="50" />
+        <img src="https://upload.wikimedia.org/wikipedia/commons/5/5f/Windows_logo_-_2012.svg" alt="Windows" width="50" />
       </a>
     </td>
     <td>
@@ -251,6 +251,7 @@ To install the ClipCascade Windows desktop application, follow these steps:
     - When prompted, enter your **server's IP address, port number, or domain name**.
     - If encryption is enabled, ensure it is **enabled on all devices**.
     - In the **Extra Config** section, you can set a local clipboard size limit. By default, no limit is enforced (note: large file transfers may cause temporary unresponsiveness).
+    - In the **Extra Config** section, you can optionally set **SSL CA bundle** to a PEM file path if your server uses a private/internal CA.
 4. **Network Access Prompt (P2P Mode)**
     - If the server is running in **P2P mode**, you will see a Windows security prompt asking, **"Do you want to allow public and private networks to access this app?"**
 
@@ -260,6 +261,11 @@ To install the ClipCascade Windows desktop application, follow these steps:
     - Click **Allow** to enable clipboard data syncing across your devices without the help of a server. The server is needed only for signaling and authentication.
 
 **Important Note:** Since the application is not published or registered with Microsoft, you may see a warning suggesting that it could be unsafe. This is a standard precaution and does not indicate any issues with the software. You can choose to ignore this warning or temporarily disable your antivirus during installation. All source code is available in this repository, and everything is open source and free. If you prefer, you can compile the executable yourself. Feel free to review the code to ensure your comfort! **Registering the application with Microsoft requires purchasing a certificate subscription, which is quite expensive, especially for an open-source project.**
+
+To build your own desktop executable from source (`ClipCascade_Desktop/src`):
+```bash
+python3 -m PyInstaller ClipCascade_win.spec
+```
 
 The `.exe` file does not need UAC approval because it is standalone executable, while the `.msi` installer will request UAC permissions because it creates a designated folder for the software, adds a startup option, and allows for uninstallation via the Control Panel. Additionally, with the .msi installer, you have the option to choose any location to save the software. However, select locations where even when you create a file manually at that location, Windows shouldn’t prompt for permission to answer "yes or no" questions.
 
@@ -307,6 +313,7 @@ To install the ClipCascade macOS desktop application, follow these steps:
     - When prompted, enter your **server's IP address, port number, or domain name**.
     - If encryption is enabled, ensure it is **enabled on all devices**.
     - In the **Extra Config** section, you can set a local clipboard size limit. By default, no limit is enforced (note: large file transfers may cause temporary unresponsiveness).
+    - In the **Extra Config** section, you can optionally set **SSL CA bundle** to a PEM file path if your server uses a private/internal CA.
 
 7. **Network Access Prompt (P2P Mode)**
     - If the server is running in **P2P mode**, you will see a macOS security prompt asking, **"Allow "ClipCascade" to find devices on local networks?"**
@@ -322,10 +329,16 @@ To install the ClipCascade macOS desktop application, follow these steps:
 9. **Enable Auto-Startup**:
      - Right-click the **ClipCascade** icon in the dock (bottom of the screen).
      - Select **Options** and then check **Open at Login**.
-
+       
        <img src="https://github.com/user-attachments/assets/cadeb680-d1fd-4582-9d20-b41ba8713b39" alt="Startup" width="200" />
+     - Alternatively, open **Settings** → **General** → **Login Items & Extensions**, then add **ClipCascade** manually.
 
 **Important Note:** Since the application is not published or registered with Apple, you may see a warning suggesting that it could be unsafe. This is a standard precaution and does not indicate any issues with the software. You can choose to ignore this warning. All source code is available in this repository, and everything is open source and free. If you prefer, you can compile the executable yourself. Feel free to review the code to ensure your comfort! **Registering the application with Apple requires purchasing a certificate subscription, which is quite expensive, especially for an open-source project.**
+
+To build your own desktop executable from source (`ClipCascade_Desktop/src`):
+```bash
+python3 -m PyInstaller ClipCascade_macos.spec
+```
 
 [➡️ Explore Advanced Details](https://github.com/Sathvik-Rao/ClipCascade?tab=readme-ov-file#%EF%B8%8F-advanced-details)
 
@@ -484,9 +497,24 @@ Start ClipCascade by running (use sudo if needed):
    - When prompted, enter your **server's IP address, port number, or domain name**.
    - If encryption is enabled, ensure it is **enabled on all devices**.
    - In the **Extra Config** section, you can set a local clipboard size limit. By default, no limit is enforced (note: large file transfers may cause temporary unresponsiveness).
+   - In the **Extra Config** section, you can optionally set **SSL CA bundle** to a PEM file path if your server uses a private/internal CA.
 ```
 python3 main.py
 ```
+
+Linux supports optional launch arguments to manually tune behavior when needed:
+- `--gui <true|false>`: force GUI mode (`true`) or terminal/CLI mode (`false`).
+- `--xmode <true|false>`: force X11/XWayland-style clipboard path (`true`) or Wayland-style path (`false`).
+- `--polling <seconds>`: override clipboard polling interval (must be a positive number).
+
+Examples:
+```bash
+python3 main.py --gui true
+python3 main.py --gui false --xmode false --polling 3
+python3 main.py --polling 1.5
+```
+
+If these flags are not provided, ClipCascade automatically detects your environment and selects the most suitable mode.
 
 
 #### Step 5.1: Fix 'No module named `Crypto`' Error (if applicable)
@@ -1042,6 +1070,7 @@ Defines the STOMP broker password for external message handling.
 
   #### Desktop (Specific):
   - **Default File Download Location**: When this path is set, the app will save files directly to the specified location without prompting the user each time the "Download Files" button is clicked.
+  - **SSL CA bundle (optional)**: Path to a PEM file containing your root CA (or full chain) used for HTTPS/WSS verification. Leave it empty to use default public CA/OS trust. Use this field when your ClipCascade server certificate is signed by a private/internal CA (for example, corporate PKI).
   
   #### Android (Specific):
   - **Run on System Startup**: Enable this option to allow the app to automatically start on system reboot. By default, this option is disabled. If you are using the [ADB](https://github.com/Sathvik-Rao/ClipCascade?tab=readme-ov-file#adb-commands) workaround, keep this option disabled to avoid issues with the READ_LOGS permission [popup](https://github.com/Sathvik-Rao/ClipCascade?tab=readme-ov-file#adb-commands) being dismissed, which prevents clipboard monitoring in the background.
@@ -1103,7 +1132,7 @@ You can adjust these settings in the **Extra Config** section on the login page 
    | **macOS**                 | Utilizes the `pasteboard` to monitor the clipboard with polling every 0.3 seconds. Instead of checking clipboard content directly, it compares a counter to detect changes efficiently. |
    | **Linux (X11)**           | Integrates `Gtk.Clipboard` to capture clipboard changes in an event-driven manner, running in GUI mode.                                                         |
    | **Linux (XWayland, Unknown)** | Switches between `Gtk.Clipboard` (event-based) or `x-clip` (polling every 0.3 seconds) depending on permissions (requires sudo for `Gtk.Clipboard`). Both operate in GUI mode. |
-   | **Linux (Wayland, Hyprland)** | Uses `wl-clipboard` with polling every 1 seconds in CLI mode. The delay accounts for Wayland's requirement to focus a window to grab clipboard content. |
+   | **Linux (Wayland, Hyprland)** | Uses `wl-clipboard` with polling every 3 seconds in CLI mode by default. The delay accounts for Wayland's requirement to focus a window to grab clipboard content. You can override this using `--polling`. |
    | **Android**               | Uses `ClipboardManager` to capture clipboard changes in an event-driven manner.                                                                         |
 
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@
 | 🪟 Desktop ([Windows](https://github.com/Sathvik-Rao/ClipCascade?tab=readme-ov-file#-windows-desktop-application)) | 🍏 Desktop ([macOS](https://github.com/Sathvik-Rao/ClipCascade?tab=readme-ov-file#-macos-desktop-application)) | 🤖📱 Mobile ([Android](https://github.com/Sathvik-Rao/ClipCascade?tab=readme-ov-file#-android-mobile-application)) | 🐧🖱️ Desktop ([Linux_GUI](https://github.com/Sathvik-Rao/ClipCascade?tab=readme-ov-file#%EF%B8%8F-linux-desktop-application-gui--%EF%B8%8F-linux-terminal-based-application-cli)) | 🐧⌨️ Desktop ([Linux_CLI](https://github.com/Sathvik-Rao/ClipCascade?tab=readme-ov-file#%EF%B8%8F-linux-desktop-application-gui--%EF%B8%8F-linux-terminal-based-application-cli)) | 
 |-----------------------|--------------------|--------------------|--------------------|--------------------|
 | <img src="https://github.com/user-attachments/assets/369d5db5-685c-4284-946d-b6a0e1f4fef9" alt="Desktop (Windows) - 1" width="360" /> | <img src="https://github.com/user-attachments/assets/2c0a7f4d-652c-4f4c-97e9-ee9b9d66f03f" alt="Desktop (macOS) - 1" width="360" /> | <img src="https://github.com/user-attachments/assets/a5606f3c-6d8a-434f-8f1d-03d6276e03c0" alt="Mobile (Android) - 1" width="360" /> | <img src="https://github.com/user-attachments/assets/f1acd9f4-27ee-4eb0-8696-a786a21551ed" alt="Desktop (Linux_GUI) - 1" width="360" /> | <img src="https://github.com/user-attachments/assets/f3f7c3a9-0299-4f0d-9494-5d9a102a243f" alt="Desktop (Linux_CLI) - 1" width="360" /> |
-| <img src="https://github.com/user-attachments/assets/3d51539b-69d0-4b0d-8854-e262638333bd" alt="Desktop (Windows) - 2" width="240" /> | <img src="https://github.com/user-attachments/assets/3d473d8d-601e-4c78-bb7f-0684d39aef67" alt="Desktop (macOS) - 2" width="240" /> | <img src="https://github.com/user-attachments/assets/607135ff-498f-45ae-b60e-18da525b6b19" alt="Mobile (Android) - 2" width="240" /> | <img src="https://github.com/user-attachments/assets/394ab014-ae40-475d-8109-d95c9a69645b" alt="Desktop (Linux_GUI) - 2" width="240" /> | <img src="https://github.com/user-attachments/assets/daf0a4ac-4dcc-4547-9171-7bb0546f6712" alt="Desktop (Linux_non_GUI) - 2" width="240" /> |
+| <img src="https://github.com/user-attachments/assets/3d51539b-69d0-4b0d-8854-e262638333bd" alt="Desktop (Windows) - 2" width="240" /> | <img src="https://github.com/user-attachments/assets/3d473d8d-601e-4c78-bb7f-0684d39aef67" alt="Desktop (macOS) - 2" width="240" /> | <img src="https://github.com/user-attachments/assets/607135ff-498f-45ae-b60e-18da525b6b19" alt="Mobile (Android) - 2" width="240" /> | <img src="https://github.com/user-attachments/assets/394ab014-ae40-475d-8109-d95c9a69645b" alt="Desktop (Linux_GUI) - 2" width="240" /> | <img src="https://github.com/user-attachments/assets/daf0a4ac-4dcc-4547-9171-7bb0546f6712" alt="Desktop (Linux_CLI) - 2" width="240" /> |
 
 
 
@@ -396,7 +396,8 @@ After executing three ADB commands, when you click the **Start** button, you wil
 ### 🐧🖱️ Linux Desktop Application (GUI) / 🐧⌨️ Linux Terminal-Based Application (CLI):
 
 This guide provides step-by-step instructions to install ClipCascade on Debian/Ubuntu, Fedora, and Arch-based systems. While the commands are specifically tailored for these distributions, you can adapt the process for other Linux distributions with minor modifications. The Linux code is available on the [Releases page](https://github.com/Sathvik-Rao/ClipCascade/releases) as `ClipCascade_Linux.zip`. Once downloaded, navigate to the `ClipCascade/` folder containing `main.py`, and open a terminal in that directory.
-> **Note:** Linux systems use different display servers, primarily `X11` and `Wayland`. `Wayland` can also include `XWayland`, which supports `X` sessions. The program automatically detects the display server and selects the appropriate interface, either **GUI** or **CLI**, based on the environment.
+
+> **Note:** On startup, ClipCascade reads a handful of **standard environment variables** your desktop session already sets—such as `XDG_SESSION_TYPE`, `WAYLAND_DISPLAY`, and `DISPLAY`—so it knows which display and clipboard APIs to use (the same kind of information any graphical app needs locally). From those values it classifies the environment as **X11**, **XWayland** (a Wayland session that also exposes an X11 socket), **Hyprland**, **native Wayland**, or **unknown**. That classification picks **both** the default clipboard integration (X11-style versus Wayland-style tools) **and** the default user interface (**GTK tray / GUI** versus **terminal-based CLI**). **X11**, **XWayland**, and **unknown** default to the X11-style clipboard path and **GUI**; **native Wayland** and **Hyprland** default to the Wayland-style clipboard path and **CLI**. You can override defaults with `--gui` and `--xmode` (see below)—for example, **`--gui true` on Wayland** still uses the Wayland clipboard path unless you also change `--xmode`.
 
 #### Step 1: Check for updates and install required packages
 
@@ -502,9 +503,11 @@ python3 main.py
 ```
 
 Linux supports optional launch arguments to manually tune behavior when needed:
-- `--gui <true|false>`: force GUI mode (`true`) or terminal/CLI mode (`false`).
-- `--xmode <true|false>`: force X11/XWayland-style clipboard path (`true`) or Wayland-style path (`false`).
+- `--gui <true|false>`: force **GUI** (tray / GTK login) with `true`, or **terminal CLI** with `false`, independent of the auto-selected default.
+- `--xmode <true|false>`: force **X11 / XWayland-style** clipboard handling (`xclip`, GTK clipboard when applicable) with `true`, or **Wayland-style** handling (`wl-clipboard`) with `false`.
 - `--polling <seconds>`: override clipboard polling interval (must be a positive number).
+
+When flags are omitted, **display-server detection** sets the default `--xmode` behavior, and the default **GUI vs CLI** follows that same classification (GUI for X11, XWayland, and unknown; CLI for native Wayland and Hyprland). Use `--gui` / `--xmode` if your session variables do not match how you want the app to run.
 
 Examples:
 ```bash
@@ -513,7 +516,7 @@ python3 main.py --gui false --xmode false --polling 3
 python3 main.py --polling 1.5
 ```
 
-If these flags are not provided, ClipCascade automatically detects your environment and selects the most suitable mode.
+If these flags are not provided, ClipCascade automatically detects your environment and selects the most suitable clipboard path and interface.
 
 
 #### Step 5.1: Fix 'No module named `Crypto`' Error (if applicable)
@@ -1129,9 +1132,10 @@ You can adjust these settings in the **Extra Config** section on the login page 
    |---------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
    | **Windows**               | Uses `win32gui`, `win32api`, `win32con`, and `win32clipboard` to capture clipboard changes in an event-driven manner.                                         |
    | **macOS**                 | Utilizes the `pasteboard` to monitor the clipboard with polling every 0.3 seconds. Instead of checking clipboard content directly, it compares a counter to detect changes efficiently. |
-   | **Linux (X11)**           | Integrates `Gtk.Clipboard` to capture clipboard changes in an event-driven manner, running in GUI mode.                                                         |
-   | **Linux (XWayland, Unknown)** | Switches between `Gtk.Clipboard` (event-based) or `x-clip` (polling every 0.3 seconds) depending on permissions (requires sudo for `Gtk.Clipboard`). Both operate in GUI mode. |
-   | **Linux (Wayland, Hyprland)** | Uses `wl-clipboard` with polling every 3 seconds in CLI mode by default. The delay accounts for Wayland's requirement to focus a window to grab clipboard content. You can override this using `--polling`. |
+   | **Linux (X11)**           | Integrates `Gtk.Clipboard` to capture clipboard changes in an event-driven manner. **Default UI:** GUI (tray).                                                         |
+   | **Linux (XWayland)**      | Same X11-style stack as above: `Gtk.Clipboard` when possible, otherwise `xclip` polling (~0.3s). **Default UI:** GUI—not CLI. Detection treats XWayland as a Wayland session that also has `DISPLAY` and `WAYLAND_DISPLAY` set. |
+   | **Linux (Unknown)**     | Treated like the X11-style path for defaults (GTK / `xclip` as above). **Default UI:** GUI. |
+   | **Linux (native Wayland, Hyprland)** | Tries **`wl-paste --watch` first** (**event-driven** where the compositor supports it: clipboard changes wake the watcher instead of a fixed timer). If `--watch` is not supported or exits immediately, falls back to **polling** `wl-paste -l` (default every 3 seconds; `--polling`). **Default UI:** CLI (terminal). Override with `--gui` / `--xmode`. |
    | **Android**               | Uses `ClipboardManager` to capture clipboard changes in an event-driven manner.                                                                         |
 
 

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
-  "android": "3.1.0",
-  "windows": "3.0.0",
-  "linux_gui": "3.0.0",
-  "linux_non_gui": "3.0.0",
-  "macos": "3.0.0",
+  "android": "3.2.0",
+  "windows": "3.2.0",
+  "linux_gui": "3.2.0",
+  "linux_non_gui": "3.2.0",
+  "macos": "3.2.0",
   "server": "3.1.0"
 }


### PR DESCRIPTION
# v3.2.0 — Desktop & mobile

## Summary

Changes from `3.1.0` through this branch for **ClipCascade_Desktop** and **ClipCascade_Mobile**.

## Changes

- Refurbish P2P signaling and data-channel handling on desktop and Android
- Fix race conditions in P2P-related flows
- Fix incorrect / negative peer counts
- Fix peers disconnecting or getting stuck after system sleep; cap wait when closing peer connections after sleep
- Add WebSocket ping/pong and data-channel heartbeats for idle sessions
- Linux: optional Wayland clipboard watch (`wl-paste --watch`) alongside polling
- Linux: increase wl-clipboard timeouts for reliability
- Linux: CLI overrides `--gui` / `--xmode` (`true` or `false`) and `--polling` (seconds) for clipboard polling
- macOS: pasteboard access locking for safer reads
- macOS: hide Dock icon when running as a tray app; clearer startup error dialog (#141)
- Windows / macOS: add PyInstaller spec files for reproducible builds
- Login (GUI + CLI): optional custom SSL CA path
- CLI: keep retrying when SSL CA path is invalid
- Minor STOMP / WebSocket client and connection handling tweaks
- Tray: icon updates (#139)
- UI: login field tooltips; remove tab focus from checkboxes; config label color tweak
- Window: center on primary monitor
- Packaging: add `pyproject.toml` for the Linux desktop Python package (#116)
- Dependencies: optional / platform-specific extras via `sys_platform` markers
- Android: foreground service rework for smoother background sync
- Android: strip escape sequences from UI messages
- Version bump to 3.2.0 (desktop constants / packaging as applicable)

