### PR TITLE
feat(server): persist HttpSession across server restarts

### DIFF
--- a/ClipCascade_Server/ClipCascade_Backend/pom.xml
+++ b/ClipCascade_Server/ClipCascade_Backend/pom.xml
@@ -54,6 +54,13 @@
 			<groupId>org.springframework.session</groupId>
 			<artifactId>spring-session-core</artifactId>
 		</dependency>
+		<!-- Persists HttpSession to the relational store so a container restart
+		     does not invalidate every active session and force all clients to
+		     re-authenticate. -->
+		<dependency>
+			<groupId>org.springframework.session</groupId>
+			<artifactId>spring-session-jdbc</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-thymeleaf</artifactId>

--- a/ClipCascade_Server/ClipCascade_Backend/src/main/java/com/acme/clipcascade/config/SecurityConfiguration.java
+++ b/ClipCascade_Server/ClipCascade_Backend/src/main/java/com/acme/clipcascade/config/SecurityConfiguration.java
@@ -8,11 +8,13 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.session.SessionRegistry;
-import org.springframework.security.core.session.SessionRegistryImpl;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.session.HttpSessionEventPublisher;
+import org.springframework.session.FindByIndexNameSessionRepository;
+import org.springframework.session.Session;
+import org.springframework.session.security.SpringSessionBackedSessionRegistry;
 import com.acme.clipcascade.service.BruteForceProtectionService;
 import com.acme.clipcascade.service.FacadeUserService;
 
@@ -37,10 +39,13 @@ public class SecurityConfiguration {
 		this.facadeUserService = facadeUserService;
 	}
 
-	// SessionRegistry bean to store session information
+	// Replaces the in-memory SessionRegistryImpl with a registry backed by
+	// the Spring Session repository, so server-side session state survives a
+	// restart and existing client cookies remain valid.
 	@Bean
-	public SessionRegistry sessionRegistry() {
-		return new SessionRegistryImpl();
+	public SessionRegistry sessionRegistry(
+			FindByIndexNameSessionRepository<? extends Session> sessionRepository) {
+		return new SpringSessionBackedSessionRegistry<>(sessionRepository);
 	}
 
 	// Ensures the SessionRegistry is notified of session lifecycle events
@@ -50,7 +55,9 @@ public class SecurityConfiguration {
 	}
 
 	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+	public SecurityFilterChain securityFilterChain(
+			HttpSecurity http,
+			SessionRegistry sessionRegistry) throws Exception {
 		return http
 				.authorizeHttpRequests((authorize) -> authorize
 						.requestMatchers(
@@ -78,7 +85,7 @@ public class SecurityConfiguration {
 				.sessionManagement(session -> session
 						.sessionCreationPolicy(SessionCreationPolicy.ALWAYS) // Always create a new session
 						.maximumSessions(-1) // Allow unlimited sessions
-						.sessionRegistry(sessionRegistry()) // Use the session registry
+						.sessionRegistry(sessionRegistry)
 						.expiredSessionStrategy(new CustomExpiredSession())) // Custom expired session strategy
 				.build();
 	}

--- a/ClipCascade_Server/ClipCascade_Backend/src/main/java/com/acme/clipcascade/model/UserPrincipal.java
+++ b/ClipCascade_Server/ClipCascade_Backend/src/main/java/com/acme/clipcascade/model/UserPrincipal.java
@@ -1,5 +1,6 @@
 package com.acme.clipcascade.model;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -10,11 +11,20 @@ import org.springframework.security.core.userdetails.UserDetails;
 import com.acme.clipcascade.constants.RoleConstants;
 import com.acme.clipcascade.service.BruteForceProtectionService;
 
-public class UserPrincipal implements UserDetails {
+public class UserPrincipal implements UserDetails, Serializable {
+
+    // Spring Session (JDBC store) serializes the SecurityContext, which holds
+    // an Authentication whose principal is this UserPrincipal, so the class
+    // must be Serializable.
+    private static final long serialVersionUID = 1L;
 
     private Users user;
 
-    private final BruteForceProtectionService bruteForceProtectionService;
+    // Spring-managed service bean: not Serializable and must not be persisted
+    // alongside the user. Marked transient so it is skipped by the JDK
+    // serializer; after deserialization the field is null and the null-guard
+    // in isAccountNonLocked() takes over.
+    private final transient BruteForceProtectionService bruteForceProtectionService;
 
     public UserPrincipal(
             Users user,
@@ -26,6 +36,16 @@ public class UserPrincipal implements UserDetails {
 
     @Override
     public boolean isAccountNonLocked() {
+
+        // When this principal was rehydrated from a persisted session the
+        // transient service is null. Brute-force protection only needs to
+        // gate the login flow itself; an already-authenticated session being
+        // restored has cleared that gate previously, so skipping the check
+        // here is safe. A fresh login request goes through MyUserDetailsService
+        // and constructs a UserPrincipal that does have the service wired in.
+        if (bruteForceProtectionService == null) {
+            return true;
+        }
 
         // validate attempt using brute force protection
         return bruteForceProtectionService.recordAndValidateAttempt(user.getUsername());

--- a/ClipCascade_Server/ClipCascade_Backend/src/main/java/com/acme/clipcascade/model/Users.java
+++ b/ClipCascade_Server/ClipCascade_Backend/src/main/java/com/acme/clipcascade/model/Users.java
@@ -1,5 +1,7 @@
 package com.acme.clipcascade.model;
 
+import java.io.Serializable;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -8,7 +10,12 @@ import jakarta.validation.constraints.NotNull;
 
 @Entity
 @Table(name = "users")
-public class Users {
+public class Users implements Serializable {
+
+    // Held by UserPrincipal, which is serialized as part of the
+    // SecurityContext when sessions are persisted via Spring Session, so
+    // this entity must also be Serializable.
+    private static final long serialVersionUID = 1L;
 
     @Id
     @NotNull(message = "Username is required") // Validation constraint at application level

--- a/ClipCascade_Server/ClipCascade_Backend/src/main/java/com/acme/clipcascade/service/SessionService.java
+++ b/ClipCascade_Server/ClipCascade_Backend/src/main/java/com/acme/clipcascade/service/SessionService.java
@@ -1,26 +1,37 @@
 package com.acme.clipcascade.service;
 
-import java.util.List;
+import java.util.Map;
 
-import org.springframework.security.core.session.SessionInformation;
-import org.springframework.security.core.session.SessionRegistry;
+import org.springframework.session.FindByIndexNameSessionRepository;
+import org.springframework.session.Session;
 import org.springframework.stereotype.Service;
 
-import org.springframework.security.core.userdetails.UserDetails;
 import com.acme.clipcascade.utils.UserValidator;
 
 import jakarta.persistence.EntityNotFoundException;
 
 @Service
 public class SessionService {
-    private final SessionRegistry sessionRegistry;
+
+    // SpringSessionBackedSessionRegistry.getAllPrincipals() throws
+    // UnsupportedOperationException because Spring Session does not expose a
+    // way to enumerate every principal across the store. The previous
+    // implementation, which scanned that list and filtered by username,
+    // therefore broke every "log out user X" code path (admin force-logoff,
+    // self "Logoff from All Devices", username/password change, user delete).
+    //
+    // Looking sessions up by indexed principal name and deleting them
+    // directly preserves the original semantics — the client cookie is
+    // invalidated — while also being O(n) only in the user's own sessions.
+
+    private final FindByIndexNameSessionRepository<? extends Session> sessionRepository;
     private final UserService userService;
 
     public SessionService(
-            SessionRegistry sessionRegistry,
+            FindByIndexNameSessionRepository<? extends Session> sessionRepository,
             UserService userService) {
 
-        this.sessionRegistry = sessionRegistry;
+        this.sessionRepository = sessionRepository;
         this.userService = userService;
     }
 
@@ -35,26 +46,16 @@ public class SessionService {
             throw new EntityNotFoundException("User not found");
         }
 
-        // Iterate over all principals in the SessionRegistry
-        List<Object> principals = sessionRegistry.getAllPrincipals();
-        boolean foundUser = false;
+        // Indexed lookup against the SPRING_SESSION.PRINCIPAL_NAME column.
+        Map<String, ? extends Session> sessions = sessionRepository.findByPrincipalName(username);
 
-        for (Object principal : principals) {
-            if (principal instanceof UserDetails userDetails) { // <- Spring Security UserDetails
-                if (userDetails.getUsername().equals(username)) {
-                    foundUser = true;
-                    // Get all active sessions for this principal
-                    List<SessionInformation> sessions = sessionRegistry.getAllSessions(principal, false);
-                    // Expire each session to effectively force logout
-                    for (SessionInformation sessionInfo : sessions) {
-                        sessionInfo.expireNow(); // mark it as expired
-                    }
-                }
-            }
+        if (sessions.isEmpty()) {
+            return "No active sessions found for username: " + username;
         }
 
-        if (!foundUser) {
-            return "No active sessions found for username: " + username;
+        // Deleting the session row immediately invalidates the client cookie.
+        for (String sessionId : sessions.keySet()) {
+            sessionRepository.deleteById(sessionId);
         }
 
         return "User '" + username + "' has been logged out of all active sessions.";

--- a/ClipCascade_Server/ClipCascade_Backend/src/main/resources/application.properties
+++ b/ClipCascade_Server/ClipCascade_Backend/src/main/resources/application.properties
@@ -3,7 +3,7 @@ spring.application.name=ClipCascade
 # ---------------------------------------
 # Database Configuration
 # ---------------------------------------
-spring.datasource.url=${CC_SERVER_DB_URL:jdbc:h2:file:./database/clipcascade;CIPHER=AES;MODE=PostgreSQL}
+spring.datasource.url=${CC_SERVER_DB_URL:jdbc:h2:file:./database/clipcascade;CIPHER=AES;MODE=PostgreSQL;WRITE_DELAY=0}
 spring.datasource.driverClassName=${CC_SERVER_DB_DRIVER:org.h2.Driver}
 spring.datasource.username=${CC_SERVER_DB_USERNAME:clipcascade}
 spring.datasource.password=${CC_SERVER_DB_PASSWORD:QjuGlhE3uwylBBANMkX1 o2MdEoFgbU5XkFvTftky}
@@ -22,6 +22,19 @@ spring.jpa.properties.hibernate.dialect=${CC_SERVER_DB_HIBERNATE_DIALECT:org.hib
 # ---------------------------------------
 server.port=${CC_PORT:8080}
 server.servlet.session.timeout=${CC_SESSION_TIMEOUT:525960m}
+
+# ---------------------------------------
+# Spring Session (JDBC store)
+# Persists HttpSession rows in the SPRING_SESSION table so existing
+# client cookies remain valid across server/container restarts.
+# The cookie name is pinned to JSESSIONID for backward compatibility
+# with desktop and mobile clients.
+# ---------------------------------------
+spring.session.store-type=jdbc
+spring.session.jdbc.initialize-schema=always
+spring.session.jdbc.table-name=SPRING_SESSION
+server.servlet.session.cookie.name=JSESSIONID
+spring.session.timeout=${CC_SESSION_TIMEOUT:525960m}
 
 
 # ---------------------------------------


### PR DESCRIPTION
## Summary

Persist `HttpSession` across server restarts so existing desktop and mobile clients are no longer forced back to the login screen on every redeploy.

Relates to #17 — long-standing self-hoster pain point. From that thread: *"A container restart will log out devices because the session keys are removed."* This PR fixes that root cause.

## What changes

- **`pom.xml`** — add `spring-session-jdbc`. (`spring-session-core` was already on the classpath but had no store backend wired in, so persistence was never actually active.)
- **`application.properties`**
  - enable the JDBC store with automatic schema initialization
  - pin `server.servlet.session.cookie.name=JSESSIONID` so already-deployed clients keep working with no update
  - add `WRITE_DELAY=0` to the default H2 URL so session writes are durable across an abrupt `docker stop` (without it, the most recent session updates can be lost from the file store on shutdown)
- **`SecurityConfiguration`** — swap `SessionRegistryImpl` for `SpringSessionBackedSessionRegistry`, so the admin "active devices" view also reads from the persistent store.
- **`UserPrincipal` / `Users`** — implement `Serializable`. `BruteForceProtectionService` is marked `transient` (it is a Spring bean, not session state); `isAccountNonLocked()` is null-guarded for the rehydrated path so a restored session doesn't NPE on the now-null service reference. (Brute-force gating still applies to fresh login attempts, which always go through `MyUserDetailsService` and get a fully wired principal.)
- **`SessionService`** — `SpringSessionBackedSessionRegistry.getAllPrincipals()` deliberately throws `UnsupportedOperationException` (Spring Session doesn't index across all principals). The previous implementation called it from **every** "log this user out" path:
  - admin force-logoff (`ClipCascadeController#486`)
  - user-initiated "Log off from all devices" (`ClipCascadeController#495`)
  - rename username (`FacadeUserService#79`)
  - change password (`FacadeUserService#99`)
  - delete user (`FacadeUserService#129`)

  All five would now return HTTP 500. Replaced with `FindByIndexNameSessionRepository.findByPrincipalName()` + `deleteById()` — same end-user semantics (cookie invalidated immediately), indexed lookup, no full scan.

## Compatibility

- Cookie name is unchanged (`JSESSIONID`); existing desktop and mobile clients continue to work without any client-side update.
- On first startup the JDBC store auto-creates two new tables in the existing H2 database: `SPRING_SESSION` and `SPRING_SESSION_ATTRIBUTES`. Application tables are unaffected.
- No new env vars introduced. Default behavior changes from "in-memory, lost on restart" to "persistent on disk".

## How to verify

```bash
docker compose up -d
# Log in from any client; you get a JSESSIONID cookie.
docker compose restart clipcascade
# The same cookie still authenticates — no forced re-login.
```

Verified locally: login → `docker restart` → request to `/admin/advance` with the original cookie returns HTTP 200 and renders the dashboard.

## Notes

Happy to split this further if preferred (e.g. `Serializable` prep first, then the registry swap, then `SessionService`). Kept it as one PR because the three pieces are individually broken without each other — adding `spring-session-jdbc` without `Serializable` on the principal would crash on the first request, and swapping the registry without fixing `SessionService` would 500 every user-management action.